### PR TITLE
feat: Drizzle schema, migrations, and libSQL connection

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,5 @@
+# Local SQLite file (development)
+DATABASE_URL=file:local.db
+
+# Required for Auth.js — generate with: openssl rand -base64 32
+AUTH_SECRET=your-secret-here

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env*.example
+
+# local sqlite database
+local.db
 
 # vercel
 .vercel

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  dialect: 'sqlite',
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dbCredentials: {
+    // drizzle-kit does not load .env.local; fall back to local file for dev
+    url: process.env.DATABASE_URL ?? 'file:local.db',
+  },
+});

--- a/drizzle/0000_married_hannibal_king.sql
+++ b/drizzle/0000_married_hannibal_king.sql
@@ -1,0 +1,27 @@
+CREATE TABLE `trips` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`student_id` integer NOT NULL,
+	`created_by` integer NOT NULL,
+	`trip_date` text NOT NULL,
+	`location_type` text NOT NULL,
+	`weather` text NOT NULL,
+	`daytime_minutes` integer DEFAULT 0 NOT NULL,
+	`nighttime_minutes` integer DEFAULT 0 NOT NULL,
+	`notes` text,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`student_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `users` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`username` text NOT NULL,
+	`password_hash` text NOT NULL,
+	`name` text NOT NULL,
+	`user_type` text NOT NULL,
+	`parent_id` integer,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`parent_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_username_unique` ON `users` (`username`);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,210 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5f53305d-017f-43d7-b934-382ac3cd75c3",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "trips": {
+      "name": "trips",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trip_date": {
+          "name": "trip_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weather": {
+          "name": "weather",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daytime_minutes": {
+          "name": "daytime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "nighttime_minutes": {
+          "name": "nighttime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trips_student_id_users_id_fk": {
+          "name": "trips_student_id_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_parent_id_users_id_fk": {
+          "name": "users_parent_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1776047075584,
+      "tag": "0000_married_hannibal_king",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate"
   },
   "dependencies": {
     "@libsql/client": "^0.17.2",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import * as schema from './schema';
+
+const client = createClient({
+  url: process.env.DATABASE_URL!,
+});
+
+export const db = drizzle(client, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,43 @@
+import { sqliteTable, text, integer, type AnySQLiteColumn } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
+
+export const userTypes = ['parent', 'student'] as const;
+export const locationTypes = ['highway', 'residential', 'rural', 'urban', 'parking_lot', 'race_track'] as const;
+export const weatherConditions = ['clear', 'rain', 'snow', 'fog', 'ice'] as const;
+
+export type UserType = (typeof userTypes)[number];
+export type LocationType = (typeof locationTypes)[number];
+export type WeatherCondition = (typeof weatherConditions)[number];
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  username: text('username').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
+  name: text('name').notNull(),
+  userType: text('user_type', { enum: userTypes }).notNull(),
+  // null for parent accounts; references users.id for student accounts
+  parentId: integer('parent_id').references((): AnySQLiteColumn => users.id, { onDelete: 'cascade' }),
+  createdAt: text('created_at').notNull().default(sql`(current_timestamp)`),
+});
+
+export const trips = sqliteTable('trips', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  studentId: integer('student_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  createdBy: integer('created_by')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  tripDate: text('trip_date').notNull(),
+  locationType: text('location_type', { enum: locationTypes }).notNull(),
+  weather: text('weather', { enum: weatherConditions }).notNull(),
+  daytimeMinutes: integer('daytime_minutes').notNull().default(0),
+  nighttimeMinutes: integer('nighttime_minutes').notNull().default(0),
+  notes: text('notes'),
+  createdAt: text('created_at').notNull().default(sql`(current_timestamp)`),
+});
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
+export type Trip = typeof trips.$inferSelect;
+export type NewTrip = typeof trips.$inferInsert;


### PR DESCRIPTION
## Summary
- Adds `users` and `trips` tables via Drizzle ORM schema with full enum typing
- Self-referencing FK on `users.parent_id` for parent-student relationship
- `drizzle.config.ts` using `sqlite` dialect (works for local file and Turso)
- `db:generate` and `db:migrate` scripts wired to drizzle-kit
- `.env.local.example` documents `DATABASE_URL` and `AUTH_SECRET`

## Test plan
- [ ] `npm run db:generate` produces a migration file in `drizzle/`
- [ ] `npm run db:migrate` creates `local.db` with `users` and `trips` tables
- [ ] `sqlite3 local.db ".schema"` shows correct columns, FKs, and unique index on username
- [ ] `npx tsc --noEmit` passes with no errors

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)