### PR TITLE
feat: Auth.js credentials provider with register and login

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -6,8 +6,8 @@ and generate a printable report matching the Illinois SOS 50-hour requirement.
 
 ## Users (MVP)
 Two account types: parent and student.
-- Parents self-register (username + password)
-- Parents create student accounts from their dashboard (parent sets username + password for student)
+- Parents self-register (email + password)
+- Parents create student accounts from their dashboard (parent sets student email + password)
 - Students cannot self-register
 - Both parents and students can log, edit, and delete trips
 - Students can view their own dashboard and report only
@@ -18,7 +18,7 @@ Two account types: parent and student.
 - v1.5: iOS app with GPS-based start/stop trip tracking
 
 ## Data Model
-**users**: id, username, password_hash, name, user_type, parent_id, created_at
+**users**: id, email, password_hash, name, user_type, parent_id, created_at
 **trips**: id, student_id, created_by, trip_date, location_type, weather, daytime_minutes,
            nighttime_minutes, notes, created_at
 
@@ -61,5 +61,5 @@ Nighttime | Nighttime Total | Grand Total | Initials
 - nighttime_minutes: integer, 0 to 600
 - At least one of daytime_minutes or nighttime_minutes must be > 0
 - notes: optional, max 500 characters
-- username: required, 3 to 32 chars, alphanumeric plus underscore
+- email: required, valid email format, unique across all users
 - password: required, minimum 8 characters

--- a/drizzle/0000_glorious_zarek.sql
+++ b/drizzle/0000_glorious_zarek.sql
@@ -15,7 +15,7 @@ CREATE TABLE `trips` (
 --> statement-breakpoint
 CREATE TABLE `users` (
 	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`username` text NOT NULL,
+	`email` text NOT NULL,
 	`password_hash` text NOT NULL,
 	`name` text NOT NULL,
 	`user_type` text NOT NULL,
@@ -24,4 +24,4 @@ CREATE TABLE `users` (
 	FOREIGN KEY (`parent_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX `users_username_unique` ON `users` (`username`);
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "5f53305d-017f-43d7-b934-382ac3cd75c3",
+  "id": "32c1fc0f-bd47-4297-b90d-89e06ebcc3dd",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "trips": {
@@ -124,8 +124,8 @@
           "notNull": true,
           "autoincrement": true
         },
-        "username": {
-          "name": "username",
+        "email": {
+          "name": "email",
           "type": "text",
           "primaryKey": false,
           "notNull": true,
@@ -169,10 +169,10 @@
         }
       },
       "indexes": {
-        "users_username_unique": {
-          "name": "users_username_unique",
+        "users_email_unique": {
+          "name": "users_email_unique",
           "columns": [
-            "username"
+            "email"
           ],
           "isUnique": true
         }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1776047075584,
-      "tag": "0000_married_hannibal_king",
+      "when": 1776048409657,
+      "tag": "0000_glorious_zarek",
       "breakpoints": true
     }
   ]

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+export { auth as default } from '@/auth';
+
+export const config = {
+  matcher: [
+    /*
+     * Match all paths except:
+     * - api/auth (NextAuth endpoints)
+     * - _next/static, _next/image (Next.js internals)
+     * - favicon.ico
+     * - /login, /register (public auth pages)
+     */
+    '/((?!api/auth|_next/static|_next/image|favicon.ico|login|register).*)',
+  ],
+};

--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import { AuthError } from 'next-auth';
+import { signIn } from '@/auth';
+
+export type LoginState = { error: string } | undefined;
+
+export async function loginAction(
+  _prev: LoginState,
+  formData: FormData
+): Promise<LoginState> {
+  try {
+    await signIn('credentials', {
+      username: formData.get('username'),
+      password: formData.get('password'),
+      redirectTo: '/dashboard',
+    });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return { error: 'Invalid username or password.' };
+    }
+    // signIn throws a redirect — re-throw so Next.js can handle it
+    throw error;
+  }
+}

--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -11,15 +11,14 @@ export async function loginAction(
 ): Promise<LoginState> {
   try {
     await signIn('credentials', {
-      username: formData.get('username'),
+      email: formData.get('email'),
       password: formData.get('password'),
       redirectTo: '/dashboard',
     });
   } catch (error) {
     if (error instanceof AuthError) {
-      return { error: 'Invalid username or password.' };
+      return { error: 'Invalid email or password.' };
     }
-    // signIn throws a redirect — re-throw so Next.js can handle it
     throw error;
   }
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useActionState } from 'react';
+import Link from 'next/link';
+import { loginAction } from './actions';
+
+export default function LoginPage() {
+  const [state, action, pending] = useActionState(loginAction, undefined);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 p-8 bg-white rounded-lg shadow">
+        <h1 className="text-2xl font-semibold text-gray-900">Sign in</h1>
+
+        <form action={action} className="space-y-4">
+          <div>
+            <label htmlFor="username" className="block text-sm font-medium text-gray-700">
+              Username
+            </label>
+            <input
+              id="username"
+              name="username"
+              type="text"
+              required
+              autoComplete="username"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              autoComplete="current-password"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+
+          {state?.error && (
+            <p className="text-sm text-red-600">{state.error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={pending}
+            className="w-full rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {pending ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
+
+        <p className="text-center text-sm text-gray-600">
+          Need an account?{' '}
+          <Link href="/register" className="text-blue-600 hover:underline">
+            Register
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -14,16 +14,16 @@ export default function LoginPage() {
 
         <form action={action} className="space-y-4">
           <div>
-            <label htmlFor="username" className="block text-sm font-medium text-gray-700">
-              Username
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              Email
             </label>
             <input
-              id="username"
-              name="username"
-              type="text"
+              id="email"
+              name="email"
+              type="email"
               required
-              autoComplete="username"
-              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              autoComplete="email"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
             />
           </div>
 
@@ -37,7 +37,7 @@ export default function LoginPage() {
               type="password"
               required
               autoComplete="current-password"
-              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
             />
           </div>
 

--- a/src/app/(auth)/register/actions.ts
+++ b/src/app/(auth)/register/actions.ts
@@ -9,21 +9,21 @@ import { users } from '@/db/schema';
 
 export type RegisterState = { errors: Record<string, string> } | undefined;
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export async function registerAction(
   _prev: RegisterState,
   formData: FormData
 ): Promise<RegisterState> {
   const name = (formData.get('name') as string)?.trim();
-  const username = (formData.get('username') as string)?.trim();
+  const email = (formData.get('email') as string)?.trim().toLowerCase();
   const password = (formData.get('password') as string) ?? '';
 
   const errors: Record<string, string> = {};
 
   if (!name) errors.name = 'Name is required.';
-  if (!username || username.length < 3 || username.length > 32) {
-    errors.username = 'Username must be 3 to 32 characters.';
-  } else if (!/^[a-zA-Z0-9_]+$/.test(username)) {
-    errors.username = 'Username may only contain letters, numbers, and underscores.';
+  if (!email || !EMAIL_RE.test(email)) {
+    errors.email = 'A valid email address is required.';
   }
   if (password.length < 8) {
     errors.password = 'Password must be at least 8 characters.';
@@ -31,29 +31,27 @@ export async function registerAction(
 
   if (Object.keys(errors).length > 0) return { errors };
 
-  // Check uniqueness
   const [existing] = await db
     .select({ id: users.id })
     .from(users)
-    .where(eq(users.username, username));
+    .where(eq(users.email, email));
 
   if (existing) {
-    return { errors: { username: 'That username is already taken.' } };
+    return { errors: { email: 'An account with that email already exists.' } };
   }
 
   const passwordHash = await bcrypt.hash(password, 12);
 
   await db.insert(users).values({
-    username,
+    email,
     passwordHash,
     name,
     userType: 'parent',
   });
 
-  // Sign in immediately after registering
   try {
     await signIn('credentials', {
-      username,
+      email,
       password,
       redirectTo: '/dashboard',
     });

--- a/src/app/(auth)/register/actions.ts
+++ b/src/app/(auth)/register/actions.ts
@@ -1,0 +1,66 @@
+'use server';
+
+import { eq } from 'drizzle-orm';
+import bcrypt from 'bcryptjs';
+import { AuthError } from 'next-auth';
+import { signIn } from '@/auth';
+import { db } from '@/db';
+import { users } from '@/db/schema';
+
+export type RegisterState = { errors: Record<string, string> } | undefined;
+
+export async function registerAction(
+  _prev: RegisterState,
+  formData: FormData
+): Promise<RegisterState> {
+  const name = (formData.get('name') as string)?.trim();
+  const username = (formData.get('username') as string)?.trim();
+  const password = (formData.get('password') as string) ?? '';
+
+  const errors: Record<string, string> = {};
+
+  if (!name) errors.name = 'Name is required.';
+  if (!username || username.length < 3 || username.length > 32) {
+    errors.username = 'Username must be 3 to 32 characters.';
+  } else if (!/^[a-zA-Z0-9_]+$/.test(username)) {
+    errors.username = 'Username may only contain letters, numbers, and underscores.';
+  }
+  if (password.length < 8) {
+    errors.password = 'Password must be at least 8 characters.';
+  }
+
+  if (Object.keys(errors).length > 0) return { errors };
+
+  // Check uniqueness
+  const [existing] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.username, username));
+
+  if (existing) {
+    return { errors: { username: 'That username is already taken.' } };
+  }
+
+  const passwordHash = await bcrypt.hash(password, 12);
+
+  await db.insert(users).values({
+    username,
+    passwordHash,
+    name,
+    userType: 'parent',
+  });
+
+  // Sign in immediately after registering
+  try {
+    await signIn('credentials', {
+      username,
+      password,
+      redirectTo: '/dashboard',
+    });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return { errors: { form: 'Account created but sign-in failed. Please log in.' } };
+    }
+    throw error;
+  }
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -26,7 +26,7 @@ export default function RegisterPage() {
               type="text"
               required
               autoComplete="name"
-              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
             />
             {state?.errors?.name && (
               <p className="mt-1 text-xs text-red-600">{state.errors.name}</p>
@@ -34,19 +34,19 @@ export default function RegisterPage() {
           </div>
 
           <div>
-            <label htmlFor="username" className="block text-sm font-medium text-gray-700">
-              Username
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              Email address
             </label>
             <input
-              id="username"
-              name="username"
-              type="text"
+              id="email"
+              name="email"
+              type="email"
               required
-              autoComplete="username"
-              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              autoComplete="email"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
             />
-            {state?.errors?.username && (
-              <p className="mt-1 text-xs text-red-600">{state.errors.username}</p>
+            {state?.errors?.email && (
+              <p className="mt-1 text-xs text-red-600">{state.errors.email}</p>
             )}
           </div>
 
@@ -60,7 +60,7 @@ export default function RegisterPage() {
               type="password"
               required
               autoComplete="new-password"
-              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
             />
             {state?.errors?.password && (
               <p className="mt-1 text-xs text-red-600">{state.errors.password}</p>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useActionState } from 'react';
+import Link from 'next/link';
+import { registerAction } from './actions';
+
+export default function RegisterPage() {
+  const [state, action, pending] = useActionState(registerAction, undefined);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 p-8 bg-white rounded-lg shadow">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Create account</h1>
+          <p className="mt-1 text-sm text-gray-500">Parent accounts only. Students are added from the dashboard.</p>
+        </div>
+
+        <form action={action} className="space-y-4">
+          <div>
+            <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+              Your name
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              required
+              autoComplete="name"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+            {state?.errors?.name && (
+              <p className="mt-1 text-xs text-red-600">{state.errors.name}</p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="username" className="block text-sm font-medium text-gray-700">
+              Username
+            </label>
+            <input
+              id="username"
+              name="username"
+              type="text"
+              required
+              autoComplete="username"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+            {state?.errors?.username && (
+              <p className="mt-1 text-xs text-red-600">{state.errors.username}</p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              autoComplete="new-password"
+              className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            />
+            {state?.errors?.password && (
+              <p className="mt-1 text-xs text-red-600">{state.errors.password}</p>
+            )}
+          </div>
+
+          {state?.errors?.form && (
+            <p className="text-sm text-red-600">{state.errors.form}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={pending}
+            className="w-full rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {pending ? 'Creating account...' : 'Create account'}
+          </button>
+        </form>
+
+        <p className="text-center text-sm text-gray-600">
+          Already have an account?{' '}
+          <Link href="/login" className="text-blue-600 hover:underline">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/auth';
+
+export const { GET, POST } = handlers;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,18 @@
+import { auth } from '@/auth';
+
+export default async function DashboardPage() {
+  const session = await auth();
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <p className="mt-2 text-gray-600">
+        Welcome, {session?.user?.name}
+        {session?.user?.userType === 'parent' ? ' (parent)' : ' (student)'}
+      </p>
+      <p className="mt-4 text-sm text-gray-400">
+        Full dashboard coming in issue #7.
+      </p>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,7 @@
-import Image from "next/image";
+import { redirect } from 'next/navigation';
+import { auth } from '@/auth';
 
-export default function Home() {
-  return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
-    </div>
-  );
+export default async function RootPage() {
+  const session = await auth();
+  redirect(session ? '/dashboard' : '/login');
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,90 @@
+import NextAuth, { type DefaultSession } from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import { eq } from 'drizzle-orm';
+import bcrypt from 'bcryptjs';
+import { db } from '@/db';
+import { users } from '@/db/schema';
+
+// Extend next-auth types to carry userType and parentId through the session
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string;
+      userType: string;
+      parentId: number | null;
+    } & DefaultSession['user'];
+  }
+
+  interface User {
+    userType: string;
+    parentId: number | null;
+  }
+}
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  providers: [
+    Credentials({
+      credentials: {
+        username: {},
+        password: {},
+      },
+      async authorize(credentials) {
+        if (!credentials?.username || !credentials?.password) return null;
+
+        const [user] = await db
+          .select()
+          .from(users)
+          .where(eq(users.username, credentials.username as string));
+
+        if (!user) return null;
+
+        const valid = await bcrypt.compare(
+          credentials.password as string,
+          user.passwordHash
+        );
+        if (!valid) return null;
+
+        return {
+          id: String(user.id),
+          name: user.name,
+          userType: user.userType,
+          parentId: user.parentId ?? null,
+        };
+      },
+    }),
+  ],
+  callbacks: {
+    jwt({ token, user }) {
+      if (user) {
+        token.id = user.id;
+        token.userType = user.userType;
+        token.parentId = user.parentId;
+      }
+      return token;
+    },
+    session({ session, token }) {
+      return {
+        ...session,
+        user: {
+          ...session.user,
+          id: token.id as string,
+          userType: token.userType as string,
+          parentId: token.parentId as number | null,
+        },
+      };
+    },
+    authorized({ auth: session, request: { nextUrl } }) {
+      const isLoggedIn = !!session?.user;
+      const isPublic =
+        nextUrl.pathname === '/login' || nextUrl.pathname === '/register';
+      if (isPublic) return true;
+      return isLoggedIn;
+    },
+  },
+  pages: {
+    signIn: '/login',
+  },
+  session: {
+    maxAge: 8 * 60 * 60, // 8 hours
+  },
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -25,16 +25,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
     Credentials({
       credentials: {
-        username: {},
+        email: {},
         password: {},
       },
       async authorize(credentials) {
-        if (!credentials?.username || !credentials?.password) return null;
+        if (!credentials?.email || !credentials?.password) return null;
 
         const [user] = await db
           .select()
           .from(users)
-          .where(eq(users.username, credentials.username as string));
+          .where(eq(users.email, credentials.email as string));
 
         if (!user) return null;
 
@@ -47,6 +47,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         return {
           id: String(user.id),
           name: user.name,
+          email: user.email,
           userType: user.userType,
           parentId: user.parentId ?? null,
         };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -11,7 +11,7 @@ export type WeatherCondition = (typeof weatherConditions)[number];
 
 export const users = sqliteTable('users', {
   id: integer('id').primaryKey({ autoIncrement: true }),
-  username: text('username').notNull().unique(),
+  email: text('email').notNull().unique(),
   passwordHash: text('password_hash').notNull(),
   name: text('name').notNull(),
   userType: text('user_type', { enum: userTypes }).notNull(),


### PR DESCRIPTION
## Summary
- NextAuth v5 credentials provider with bcrypt password verification
- JWT sessions carry id, userType, and parentId (8-hour maxAge)
- Middleware protects all routes except /login and /register
- /register: parent self-registration with server-side validation, auto sign-in on success
- /login: credentials sign-in with generic error on failure
- /dashboard: placeholder (full build in issue #7)
- /: redirects to /dashboard or /login based on session

## Test plan
- [ ] Visit / — redirects to /login
- [ ] Register a new parent account — redirects to /dashboard showing name and role
- [ ] Log out (manually clear cookie for now) and log back in — session restored
- [ ] Try /dashboard without a session — redirects to /login
- [ ] Try registering with a duplicate username — shows error
- [ ] Try registering with password under 8 chars — shows error
- [ ] Build passes: npm run build

Closes #2

Generated with [Claude Code](https://claude.com/claude-code)