### PR TITLE
feat: student selector dropdown in nav

### DIFF
--- a/src/app/(app)/actions.ts
+++ b/src/app/(app)/actions.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+export async function selectStudentAction(studentId: number) {
+  const jar = await cookies();
+  jar.set('selected_student_id', String(studentId), {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30, // 30 days
+  });
+}
+
+/** Read the selected student id from the cookie (server components only). */
+export async function getSelectedStudentId(): Promise<number | null> {
+  const jar = await cookies();
+  const val = jar.get('selected_student_id')?.value;
+  return val ? Number(val) : null;
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -3,10 +3,12 @@ import { db } from '@/db';
 import { users } from '@/db/schema';
 import { eq } from 'drizzle-orm';
 import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
 import Link from 'next/link';
 import { logoutAction } from './dashboard/actions';
+import StudentSelector from './student-selector';
 
-export default async function DashboardLayout({
+export default async function AppLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -16,7 +18,6 @@ export default async function DashboardLayout({
 
   const { id, name, userType } = session.user;
 
-  // Parents see a list of their students in the nav
   let students: { id: number; name: string }[] = [];
   if (userType === 'parent') {
     students = await db
@@ -25,24 +26,39 @@ export default async function DashboardLayout({
       .where(eq(users.parentId, Number(id)));
   }
 
+  // Resolve which student is selected (cookie → first student → none)
+  const jar = await cookies();
+  const cookieVal = jar.get('selected_student_id')?.value;
+  const cookieId = cookieVal ? Number(cookieVal) : null;
+  const selectedStudent =
+    students.find((s) => s.id === cookieId) ?? students[0] ?? null;
+
   return (
     <div className="min-h-screen flex flex-col">
       {/* Top nav */}
       <header className="bg-primary border-b-4 border-accent">
         <div className="max-w-4xl mx-auto px-4 h-14 flex items-center gap-4">
           {/* App name */}
-          <Link href="/dashboard" className="text-white font-black text-sm uppercase tracking-widest shrink-0 hover:opacity-80">
+          <Link
+            href="/dashboard"
+            className="text-white font-black text-sm uppercase tracking-widest shrink-0 hover:opacity-80"
+          >
             Student Driver Log
           </Link>
 
           {/* Nav links */}
           <nav className="flex items-center gap-4 ml-4">
-            <Link href="/trips" className="text-white/80 text-xs font-bold uppercase tracking-widest hover:text-white">
+            <Link
+              href="/trips"
+              className="text-white/80 text-xs font-bold uppercase tracking-widest hover:text-white"
+            >
               Trips
             </Link>
-            {/* Only show Log Trip when a parent has students, or always for students */}
             {(userType === 'student' || (userType === 'parent' && students.length > 0)) && (
-              <Link href="/trips/new" className="rounded bg-accent px-3 py-1 text-xs font-black text-accent-foreground uppercase tracking-widest hover:opacity-90">
+              <Link
+                href="/trips/new"
+                className="rounded bg-accent px-3 py-1 text-xs font-black text-accent-foreground uppercase tracking-widest hover:opacity-90"
+              >
                 + Log Trip
               </Link>
             )}
@@ -51,24 +67,16 @@ export default async function DashboardLayout({
           <div className="flex-1" />
 
           {/* Parent: student selector */}
-          {userType === 'parent' && students.length > 0 && (
-            <div className="flex items-center gap-2">
-              <span className="text-white/50 text-[10px] uppercase tracking-widest hidden sm:block">
-                Student
-              </span>
-              {/* Static for now — issue #5 will wire up active student selection */}
-              <span className="text-accent text-xs font-bold uppercase tracking-wide">
-                {students.map((s) => s.name).join(', ')}
-              </span>
-            </div>
+          {userType === 'parent' && students.length > 0 && selectedStudent && (
+            <StudentSelector students={students} selectedId={selectedStudent.id} />
           )}
 
-          {/* Student: just show their name */}
+          {/* Student: show their own name */}
           {userType === 'student' && (
             <span className="text-white/70 text-xs uppercase tracking-wide">{name}</span>
           )}
 
-          {/* Logout */}
+          {/* Sign out */}
           <form action={logoutAction}>
             <button
               type="submit"

--- a/src/app/(app)/student-selector.tsx
+++ b/src/app/(app)/student-selector.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { selectStudentAction } from './actions';
+
+type Student = { id: number; name: string };
+
+export default function StudentSelector({
+  students,
+  selectedId,
+}: {
+  students: Student[];
+  selectedId: number;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const id = Number(e.target.value);
+    startTransition(async () => {
+      await selectStudentAction(id);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-white/50 text-[10px] uppercase tracking-widest hidden sm:block shrink-0">
+        Student
+      </span>
+      <select
+        value={selectedId}
+        onChange={handleChange}
+        disabled={isPending}
+        className="rounded bg-white/10 border border-white/20 text-white text-xs font-bold uppercase tracking-wide px-2 py-1 focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-50 cursor-pointer"
+      >
+        {students.map((s) => (
+          <option key={s.id} value={s.id} className="text-foreground bg-white normal-case font-normal">
+            {s.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/app/(app)/trips/new/actions.ts
+++ b/src/app/(app)/trips/new/actions.ts
@@ -1,15 +1,15 @@
 'use server';
 
 import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
 import { auth } from '@/auth';
 import { db } from '@/db';
 import { trips, users, locationTypes, weatherConditions } from '@/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 
 export type TripFormState = {
   success?: true;
   errors?: {
-    studentId?: string;
     tripDate?: string;
     locationType?: string;
     weather?: string;
@@ -29,18 +29,19 @@ export async function createTripAction(
   const { id: sessionId, userType } = session.user;
   const createdBy = Number(sessionId);
 
-  // Determine studentId
+  // Determine studentId from cookie (parents) or self (students)
   let studentId: number;
   if (userType === 'parent') {
-    const raw = formData.get('studentId');
-    if (!raw) return { errors: { studentId: 'Select a student.' } };
-    studentId = Number(raw);
+    const jar = await cookies();
+    const cookieVal = jar.get('selected_student_id')?.value;
+    if (!cookieVal) return { errors: { form: 'No student selected. Use the student selector in the nav.' } };
+    studentId = Number(cookieVal);
     // Verify this student belongs to the logged-in parent
     const [student] = await db
       .select({ id: users.id })
       .from(users)
-      .where(eq(users.id, studentId));
-    if (!student) return { errors: { studentId: 'Invalid student.' } };
+      .where(and(eq(users.id, studentId), eq(users.parentId, createdBy)));
+    if (!student) return { errors: { form: 'Invalid student selection.' } };
   } else {
     studentId = createdBy;
   }

--- a/src/app/(app)/trips/new/page.tsx
+++ b/src/app/(app)/trips/new/page.tsx
@@ -1,7 +1,8 @@
 import { auth } from '@/auth';
 import { db } from '@/db';
 import { users, type UserType } from '@/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import TripForm from './trip-form';
@@ -12,51 +13,79 @@ export default async function NewTripPage() {
 
   const { id, userType: userTypeRaw } = session.user;
   const userType = userTypeRaw as UserType;
+  const parentId = Number(id);
 
-  let students: { id: number; name: string }[] = [];
+  let studentName: string | null = null;
+
   if (userType === 'parent') {
-    students = await db
-      .select({ id: users.id, name: users.name })
-      .from(users)
-      .where(eq(users.parentId, Number(id)));
-  }
+    const jar = await cookies();
+    const cookieVal = jar.get('selected_student_id')?.value;
 
-  // Parent with no students can't log a trip yet
-  if (userType === 'parent' && students.length === 0) {
-    return (
-      <div className="max-w-lg space-y-6">
-        <h1 className="text-xl font-black uppercase tracking-wide text-foreground">
-          Log a Trip
-        </h1>
-        <div className="rounded border border-border bg-card p-6 space-y-3">
-          <p className="text-sm font-semibold text-foreground">No students yet</p>
-          <p className="text-sm text-muted-foreground">
-            You need to add a student before you can log a trip.
-          </p>
-          <Link
-            href="/dashboard"
-            className="inline-block rounded bg-primary px-4 py-2 text-sm font-bold text-primary-foreground uppercase tracking-widest hover:opacity-90"
-          >
-            Add a Student
-          </Link>
+    if (!cookieVal) {
+      // No student selected yet — check if any exist
+      const students = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.parentId, parentId));
+
+      if (students.length === 0) {
+        return (
+          <div className="max-w-lg space-y-6">
+            <h1 className="text-xl font-black uppercase tracking-wide text-foreground">Log a Trip</h1>
+            <div className="rounded border border-border bg-card p-6 space-y-3">
+              <p className="text-sm font-semibold text-foreground">No students yet</p>
+              <p className="text-sm text-muted-foreground">Add a student on the dashboard first.</p>
+              <Link href="/dashboard" className="inline-block rounded bg-primary px-4 py-2 text-sm font-bold text-primary-foreground uppercase tracking-widest hover:opacity-90">
+                Go to Dashboard
+              </Link>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div className="max-w-lg space-y-6">
+          <h1 className="text-xl font-black uppercase tracking-wide text-foreground">Log a Trip</h1>
+          <div className="rounded border border-border bg-card p-6 space-y-3">
+            <p className="text-sm text-muted-foreground">Select a student from the nav bar first.</p>
+          </div>
         </div>
-      </div>
-    );
+      );
+    }
+
+    const studentId = Number(cookieVal);
+    const [student] = await db
+      .select({ name: users.name })
+      .from(users)
+      .where(and(eq(users.id, studentId), eq(users.parentId, parentId)));
+
+    if (!student) {
+      return (
+        <div className="max-w-lg space-y-6">
+          <h1 className="text-xl font-black uppercase tracking-wide text-foreground">Log a Trip</h1>
+          <div className="rounded border border-border bg-card p-6">
+            <p className="text-sm text-muted-foreground">Select a student from the nav bar.</p>
+          </div>
+        </div>
+      );
+    }
+
+    studentName = student.name;
   }
 
   return (
     <div className="max-w-lg space-y-6">
       <div>
-        <h1 className="text-xl font-black uppercase tracking-wide text-foreground">
-          Log a Trip
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Record a practice driving session.
-        </p>
+        <h1 className="text-xl font-black uppercase tracking-wide text-foreground">Log a Trip</h1>
+        {studentName && (
+          <p className="text-sm text-muted-foreground mt-1">
+            Recording a session for <span className="font-semibold text-foreground">{studentName}</span>.
+          </p>
+        )}
       </div>
 
       <div className="rounded border border-border bg-card p-6">
-        <TripForm students={students} userType={userType} />
+        <TripForm />
       </div>
     </div>
   );

--- a/src/app/(app)/trips/new/trip-form.tsx
+++ b/src/app/(app)/trips/new/trip-form.tsx
@@ -6,12 +6,12 @@ import { createTripAction, type TripFormState } from './actions';
 import { locationTypes, weatherConditions } from '@/db/schema';
 
 const locationLabels: Record<typeof locationTypes[number], string> = {
-  highway:      'Highway',
-  residential:  'Residential',
-  rural:        'Rural',
-  urban:        'Urban',
-  parking_lot:  'Parking Lot',
-  race_track:   'Race Track',
+  highway:     'Highway',
+  residential: 'Residential',
+  rural:       'Rural',
+  urban:       'Urban',
+  parking_lot: 'Parking Lot',
+  race_track:  'Race Track',
 };
 
 const weatherLabels: Record<typeof weatherConditions[number], string> = {
@@ -22,25 +22,19 @@ const weatherLabels: Record<typeof weatherConditions[number], string> = {
   ice:   'Ice',
 };
 
-import type { UserType } from '@/db/schema';
-
-type Student = { id: number; name: string };
-
 const inputClass =
   'mt-1 block w-full rounded border border-input px-3 py-2 text-sm text-foreground ' +
   'placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary';
 
 const labelClass = 'block text-xs font-bold text-foreground uppercase tracking-wider';
-
 const errorClass = 'mt-1 text-xs text-destructive font-medium';
 
-export default function TripForm({ students, userType }: { students: Student[]; userType: UserType }) {
+export default function TripForm() {
   const [state, action, pending] = useActionState<TripFormState | undefined, FormData>(
     createTripAction,
     undefined
   );
 
-  const isParent = userType === 'parent';
   const today = new Date().toISOString().split('T')[0];
 
   if (state?.success) {
@@ -48,12 +42,8 @@ export default function TripForm({ students, userType }: { students: Student[]; 
       <div className="text-center space-y-6 py-4">
         <div className="space-y-2">
           <p className="text-4xl">✓</p>
-          <h2 className="text-xl font-black uppercase tracking-wide text-foreground">
-            Trip Logged
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            The driving session has been saved.
-          </p>
+          <h2 className="text-xl font-black uppercase tracking-wide text-foreground">Trip Logged</h2>
+          <p className="text-sm text-muted-foreground">The driving session has been saved.</p>
         </div>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <Link
@@ -62,7 +52,6 @@ export default function TripForm({ students, userType }: { students: Student[]; 
           >
             Go to Dashboard
           </Link>
-          {/* href to same page triggers a full navigation, resetting form state */}
           <a
             href="/trips/new"
             className="rounded border border-border px-6 py-2.5 text-sm font-bold text-foreground uppercase tracking-widest hover:bg-muted text-center"
@@ -76,22 +65,6 @@ export default function TripForm({ students, userType }: { students: Student[]; 
 
   return (
     <form action={action} className="space-y-5">
-      {/* Student selector — parents only */}
-      {isParent && (
-        <div>
-          <label htmlFor="studentId" className={labelClass}>Student</label>
-          <select id="studentId" name="studentId" required className={inputClass}>
-            <option value="">Select a student…</option>
-            {students.map((s) => (
-              <option key={s.id} value={s.id}>{s.name}</option>
-            ))}
-          </select>
-          {state?.errors?.studentId && (
-            <p className={errorClass}>{state.errors.studentId}</p>
-          )}
-        </div>
-      )}
-
       {/* Date */}
       <div>
         <label htmlFor="tripDate" className={labelClass}>Date</label>
@@ -104,9 +77,7 @@ export default function TripForm({ students, userType }: { students: Student[]; 
           defaultValue={today}
           className={inputClass}
         />
-        {state?.errors?.tripDate && (
-          <p className={errorClass}>{state.errors.tripDate}</p>
-        )}
+        {state?.errors?.tripDate && <p className={errorClass}>{state.errors.tripDate}</p>}
       </div>
 
       {/* Location type */}
@@ -118,9 +89,7 @@ export default function TripForm({ students, userType }: { students: Student[]; 
             <option key={l} value={l}>{locationLabels[l]}</option>
           ))}
         </select>
-        {state?.errors?.locationType && (
-          <p className={errorClass}>{state.errors.locationType}</p>
-        )}
+        {state?.errors?.locationType && <p className={errorClass}>{state.errors.locationType}</p>}
       </div>
 
       {/* Weather */}
@@ -132,9 +101,7 @@ export default function TripForm({ students, userType }: { students: Student[]; 
             <option key={w} value={w}>{weatherLabels[w]}</option>
           ))}
         </select>
-        {state?.errors?.weather && (
-          <p className={errorClass}>{state.errors.weather}</p>
-        )}
+        {state?.errors?.weather && <p className={errorClass}>{state.errors.weather}</p>}
       </div>
 
       {/* Minutes */}
@@ -164,13 +131,13 @@ export default function TripForm({ students, userType }: { students: Student[]; 
           />
         </div>
       </div>
-      {state?.errors?.minutes && (
-        <p className={errorClass}>{state.errors.minutes}</p>
-      )}
+      {state?.errors?.minutes && <p className={errorClass}>{state.errors.minutes}</p>}
 
       {/* Notes */}
       <div>
-        <label htmlFor="notes" className={labelClass}>Notes <span className="font-normal normal-case text-muted-foreground">(optional)</span></label>
+        <label htmlFor="notes" className={labelClass}>
+          Notes <span className="font-normal normal-case text-muted-foreground">(optional)</span>
+        </label>
         <textarea
           id="notes"
           name="notes"
@@ -179,14 +146,10 @@ export default function TripForm({ students, userType }: { students: Student[]; 
           placeholder="Any notes about the session…"
           className={inputClass + ' resize-none'}
         />
-        {state?.errors?.notes && (
-          <p className={errorClass}>{state.errors.notes}</p>
-        )}
+        {state?.errors?.notes && <p className={errorClass}>{state.errors.notes}</p>}
       </div>
 
-      {state?.errors?.form && (
-        <p className={errorClass}>{state.errors.form}</p>
-      )}
+      {state?.errors?.form && <p className={errorClass}>{state.errors.form}</p>}
 
       <div className="flex gap-3 pt-1">
         <button


### PR DESCRIPTION
## Summary
- Adds a `<select>` dropdown in the nav bar for parents with multiple students
- Selection is stored in a `selected_student_id` cookie (httpOnly, 30-day) via a server action
- On change, calls the server action then `router.refresh()` so all server components re-render with the new selection
- Defaults to the first student if no cookie is set
- Exports `getSelectedStudentId()` helper for server pages to read the active student

## Test plan
- [ ] Log in as parent with 2+ students → dropdown appears in nav showing student names
- [ ] Switch student → page refreshes, selection persists on next navigation
- [ ] Log out and back in → cookie still selects the previously chosen student

🤖 Generated with [Claude Code](https://claude.com/claude-code)