### PR TITLE
feat: PDF export via react-pdf renderer

### DIFF
--- a/PROJECT-OVERVIEW.md
+++ b/PROJECT-OVERVIEW.md
@@ -1,0 +1,140 @@
+# Student Driver Log — Project Overview
+
+## Purpose
+
+A web application for tracking Illinois learner's permit behind-the-wheel practice hours. Illinois requires student drivers to log **50 total hours** (including **10 hours at night**) before qualifying for a full license. This app replaces the paper SOS DSD X 152.4 log sheet with a structured digital tracker that generates a printable report in the same format.
+
+Personal project — John Telford tracking hours for his son Jimmy.
+
+---
+
+## Actors
+
+### Parent
+- Self-registers with email + password
+- Creates and manages student accounts (sets student email + password)
+- Can manage **multiple students** (e.g., different children)
+- Selects the active student via a nav dropdown; all views (dashboard, trips, report) filter to that student
+- Can log, edit, and delete trips on behalf of any of their students
+
+### Student
+- Account created by their parent — cannot self-register
+- Logs in with email + password set by parent
+- Can log, edit, and delete their own trips
+- Sees their own dashboard, trip list, and report only — no access to other students' data
+
+### Interactions
+```
+Parent ──creates──► Student account
+Parent ──selects──► active Student (cookie-persisted)
+Parent ──logs──────► Trip (for selected Student)
+Student ──logs─────► Trip (for themselves)
+Parent/Student ──view──► Dashboard (totals + progress)
+Parent/Student ──view──► Trips list (CRUD)
+Parent/Student ──view──► Report (printable SOS format)
+```
+
+---
+
+## Tech Stack
+
+| Layer | Choice | Notes |
+|---|---|---|
+| Framework | Next.js 15 (App Router) + TypeScript | Server Components by default |
+| Database | libSQL / SQLite (local file) → Turso (prod) | Serverless-compatible SQLite |
+| ORM | Drizzle ORM | Schema-first, type-safe, migrations |
+| Auth | Auth.js v5 — credentials provider | JWT sessions; bcrypt password hashing |
+| UI | shadcn/ui components on Tailwind CSS v4 | Components copied into repo, not a runtime dep |
+| PDF | @react-pdf/renderer | Server-side PDF generation |
+| Testing | Vitest (unit) + Playwright (e2e) | |
+| CI | GitHub Actions | |
+| Hosting | Vercel | |
+
+---
+
+## Architecture
+
+### Next.js App Router pattern
+All pages are **React Server Components** by default — they fetch data directly on the server and render HTML. Client Components (`'use client'`) are used only where browser interactivity is needed (form state, dropdowns, dialogs).
+
+Mutations use **Server Actions** — TypeScript functions marked `'use server'` that run on the server and are called directly from forms or client components. No REST API layer needed.
+
+### Route structure
+```
+/                         → redirect to /login or /dashboard
+/login                    → credentials login form
+/register                 → parent self-registration form
+
+/(app)/                   → protected layout (auth required)
+  /dashboard              → totals + progress bars + recent trips
+  /trips                  → paginated trip list with edit/delete
+  /trips/new              → trip entry form
+  /trips/[id]/edit        → pre-populated edit form
+  /report                 → printable Illinois SOS format table
+  /students/new           → parent-only: add student account
+```
+
+### Data model
+```
+users
+  id            integer PK
+  email         text UNIQUE
+  password_hash text
+  name          text
+  user_type     enum(parent, student)
+  parent_id     FK → users.id (null for parents)
+  created_at    timestamp
+
+trips
+  id                  integer PK
+  student_id          FK → users.id
+  created_by          FK → users.id
+  trip_date           text (YYYY-MM-DD)
+  location_type       enum(highway, residential, rural, urban, parking_lot, race_track)
+  weather             enum(clear, rain, snow, fog, ice)
+  daytime_minutes     integer
+  nighttime_minutes   integer
+  notes               text (optional, max 500 chars)
+  created_at          timestamp
+```
+
+### Selected-student cookie
+Parents with multiple students use a `selected_student_id` httpOnly cookie (30-day TTL) to track which student's data is in view. All server components and actions read this cookie to scope queries. If no cookie is set (e.g., first visit on a new device), the system falls back to the parent's first student automatically.
+
+### Auth flow
+Auth.js v5 issues a JWT session on login. The session carries `id`, `name`, `email`, `userType`, and `parentId`. Server components call `auth()` to get the session; server actions do the same before any mutation.
+
+---
+
+## Feature Status
+
+| # | Feature | Status |
+|---|---|---|
+| 1 | Drizzle schema + migrations + libSQL connection | Done |
+| 2 | Auth.js credentials provider (register + login) | Done |
+| 3 | shadcn/ui base components | Done |
+| 4 | Protected app layout + nav + logout | Done |
+| 5 | Trip entry form (`/trips/new`) | Done |
+| 6 | Trips list with edit and delete | Done |
+| 7 | Dashboard totals + 50h/10h progress bars | Done |
+| 8 | Printable report at `/report` (Illinois SOS format) | In review |
+| 9 | PDF export via react-pdf | Open |
+| 10 | Vitest unit test | Open |
+| 11 | Playwright e2e test | Open |
+| 12 | GitHub Actions CI | Open |
+| 13 | Turso + Vercel production deploy | Open |
+| 19 | Multiple parents per student (future) | Backlog |
+
+---
+
+## UI Theme
+
+Highway sign aesthetic — Pantone 342 Interstate green (`oklch(0.44 0.16 148)`), highway yellow accent, Overpass font (open-source Highway Gothic clone), Illinois state route shield on the login screen.
+
+---
+
+## Future Scope (not in MVP)
+
+- **v1.0** — Google OAuth (replace email/password)
+- **v1.5** — iOS app with GPS-based automatic trip start/stop tracking
+- **Future** — Multiple parents per student (e.g., two-parent households)

--- a/src/app/(app)/report/page.tsx
+++ b/src/app/(app)/report/page.tsx
@@ -4,7 +4,7 @@ import { trips, users, type UserType } from '@/db/schema';
 import { eq, and, desc } from 'drizzle-orm';
 import { redirect } from 'next/navigation';
 import { resolveSelectedStudentId } from '../actions';
-import PrintButton from './print-button';
+import ReportActions from './print-button';
 
 const locationLabels: Record<string, string> = {
   highway:     'Highway',
@@ -92,7 +92,7 @@ export default async function ReportPage() {
             <p className="text-sm text-muted-foreground mt-0.5">{studentName}</p>
           )}
         </div>
-        <PrintButton />
+        <ReportActions />
       </div>
 
       {/* Report — styled for both screen and print */}

--- a/src/app/(app)/report/print-button.tsx
+++ b/src/app/(app)/report/print-button.tsx
@@ -1,12 +1,21 @@
 'use client';
 
-export default function PrintButton() {
+export default function ReportActions() {
   return (
-    <button
-      onClick={() => window.print()}
-      className="rounded bg-primary px-4 py-2 text-sm font-bold text-primary-foreground uppercase tracking-widest hover:opacity-90 print:hidden"
-    >
-      Print
-    </button>
+    <div className="flex gap-3 print:hidden">
+      <a
+        href="/api/report/pdf"
+        download
+        className="rounded bg-primary px-4 py-2 text-sm font-bold text-primary-foreground uppercase tracking-widest hover:opacity-90"
+      >
+        Download PDF
+      </a>
+      <button
+        onClick={() => window.print()}
+        className="rounded border border-border px-4 py-2 text-sm font-bold text-foreground uppercase tracking-widest hover:bg-muted"
+      >
+        Print
+      </button>
+    </div>
   );
 }

--- a/src/app/api/report/pdf/document.tsx
+++ b/src/app/api/report/pdf/document.tsx
@@ -1,0 +1,154 @@
+import { Document, Page, View, Text, StyleSheet } from '@react-pdf/renderer';
+import type { Trip } from '@/db/schema';
+
+const locationLabels: Record<string, string> = {
+  highway: 'Highway', residential: 'Residential', rural: 'Rural',
+  urban: 'Urban', parking_lot: 'Parking Lot', race_track: 'Race Track',
+};
+const weatherLabels: Record<string, string> = {
+  clear: 'Clear', rain: 'Rain', snow: 'Snow', fog: 'Fog', ice: 'Ice',
+};
+
+function formatHMM(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${h}:${String(m).padStart(2, '0')}`;
+}
+
+// Pantone 342 in hex for PDF
+const GREEN = '#1a5c2e';
+const LIGHT_GREEN = '#e8f2eb';
+
+const s = StyleSheet.create({
+  page: { fontFamily: 'Helvetica', fontSize: 7, padding: 32, backgroundColor: '#ffffff' },
+
+  // Header
+  headerCenter: { alignItems: 'center', marginBottom: 10 },
+  headerSub:    { fontSize: 7, color: '#555555', marginBottom: 2 },
+  headerTitle:  { fontSize: 12, fontFamily: 'Helvetica-Bold', marginBottom: 4 },
+  headerMeta:   { flexDirection: 'row', gap: 24, fontSize: 7 },
+  headerLabel:  { fontFamily: 'Helvetica-Bold' },
+
+  // Table
+  table:     { width: '100%' },
+  headerRow: { flexDirection: 'row', backgroundColor: GREEN },
+  row:       { flexDirection: 'row' },
+  rowAlt:    { flexDirection: 'row', backgroundColor: LIGHT_GREEN },
+  totalsRow: { flexDirection: 'row', backgroundColor: '#d4e8da' },
+
+  // Cells
+  cell:       { borderRight: '0.5px solid #999', borderBottom: '0.5px solid #999', paddingHorizontal: 3, paddingVertical: 3, justifyContent: 'center' },
+  cellHeader: { borderRight: '0.5px solid rgba(255,255,255,0.4)', paddingHorizontal: 3, paddingVertical: 4, justifyContent: 'center', alignItems: 'center' },
+  cellText:   { color: '#111111' },
+  cellHeaderText: { color: '#ffffff', fontFamily: 'Helvetica-Bold', fontSize: 6, textAlign: 'center' },
+  cellCenter: { textAlign: 'center' },
+  cellBold:   { fontFamily: 'Helvetica-Bold' },
+
+  // Signature
+  sigRow:   { flexDirection: 'row', marginTop: 24, gap: 40 },
+  sigBlock: { flex: 1 },
+  sigLine:  { borderBottom: '0.5px solid #333', marginBottom: 3 },
+  sigLabel: { fontSize: 6, color: '#555555' },
+});
+
+// Column definitions: [label, flex, align]
+const COLS: [string, number, 'left' | 'center'][] = [
+  ['Date',                  7,  'center'],
+  ['Location of Practice', 13,  'left'],
+  ['Weather Conditions',   10,  'left'],
+  ['Daytime',               6,  'center'],
+  ['Daytime Total',         7,  'center'],
+  ['Nighttime',             6,  'center'],
+  ['Nighttime Total',       8,  'center'],
+  ['Grand Total',           7,  'center'],
+  ['Initials',              5,  'center'],
+];
+
+type Row = Trip & { runningDay: number; runningNight: number; grandTotal: number };
+
+export function ReportDocument({
+  rows,
+  studentName,
+  parentName,
+  totalDay,
+  totalNight,
+  printedDate,
+}: {
+  rows: Row[];
+  studentName: string | null;
+  parentName: string | null;
+  totalDay: number;
+  totalNight: number;
+  printedDate: string;
+}) {
+  return (
+    <Document>
+      <Page size="LETTER" orientation="landscape" style={s.page}>
+
+        {/* Header */}
+        <View style={s.headerCenter}>
+          <Text style={s.headerSub}>Illinois Secretary of State — DSD X 152.4</Text>
+          <Text style={s.headerTitle}>Behind-the-Wheel Driving Log</Text>
+          <View style={s.headerMeta}>
+            {studentName && <Text><Text style={s.headerLabel}>Student: </Text>{studentName}</Text>}
+            {parentName  && <Text><Text style={s.headerLabel}>Parent/Guardian: </Text>{parentName}</Text>}
+            <Text><Text style={s.headerLabel}>Printed: </Text>{printedDate}</Text>
+          </View>
+        </View>
+
+        {/* Table */}
+        <View style={s.table}>
+          {/* Header row */}
+          <View style={s.headerRow}>
+            {COLS.map(([label, flex]) => (
+              <View key={label} style={[s.cellHeader, { flex }]}>
+                <Text style={s.cellHeaderText}>{label.toUpperCase()}</Text>
+              </View>
+            ))}
+          </View>
+
+          {/* Data rows */}
+          {rows.map((row, i) => (
+            <View key={row.id} style={i % 2 === 1 ? s.rowAlt : s.row}>
+              <View style={[s.cell, { flex: COLS[0][1] }]}><Text style={[s.cellText, s.cellCenter]}>{row.tripDate}</Text></View>
+              <View style={[s.cell, { flex: COLS[1][1] }]}><Text style={s.cellText}>{locationLabels[row.locationType] ?? row.locationType}</Text></View>
+              <View style={[s.cell, { flex: COLS[2][1] }]}><Text style={s.cellText}>{weatherLabels[row.weather] ?? row.weather}</Text></View>
+              <View style={[s.cell, { flex: COLS[3][1] }]}><Text style={[s.cellText, s.cellCenter]}>{formatHMM(row.daytimeMinutes)}</Text></View>
+              <View style={[s.cell, { flex: COLS[4][1] }]}><Text style={[s.cellText, s.cellCenter, s.cellBold]}>{formatHMM(row.runningDay)}</Text></View>
+              <View style={[s.cell, { flex: COLS[5][1] }]}><Text style={[s.cellText, s.cellCenter]}>{formatHMM(row.nighttimeMinutes)}</Text></View>
+              <View style={[s.cell, { flex: COLS[6][1] }]}><Text style={[s.cellText, s.cellCenter, s.cellBold]}>{formatHMM(row.runningNight)}</Text></View>
+              <View style={[s.cell, { flex: COLS[7][1] }]}><Text style={[s.cellText, s.cellCenter, s.cellBold]}>{formatHMM(row.grandTotal)}</Text></View>
+              <View style={[s.cell, { flex: COLS[8][1] }]}><Text style={s.cellText}> </Text></View>
+            </View>
+          ))}
+
+          {/* Totals row */}
+          <View style={s.totalsRow}>
+            <View style={[s.cell, { flex: COLS[0][1] + COLS[1][1] + COLS[2][1] }]}>
+              <Text style={[s.cellText, s.cellBold, { textAlign: 'right' }]}>TOTALS</Text>
+            </View>
+            <View style={[s.cell, { flex: COLS[3][1] }]}><Text style={[s.cellText, s.cellCenter, s.cellBold]}>{formatHMM(totalDay)}</Text></View>
+            <View style={[s.cell, { flex: COLS[4][1] }]}><Text style={s.cellText}> </Text></View>
+            <View style={[s.cell, { flex: COLS[5][1] }]}><Text style={[s.cellText, s.cellCenter, s.cellBold]}>{formatHMM(totalNight)}</Text></View>
+            <View style={[s.cell, { flex: COLS[6][1] }]}><Text style={s.cellText}> </Text></View>
+            <View style={[s.cell, { flex: COLS[7][1] }]}><Text style={[s.cellText, s.cellCenter, s.cellBold]}>{formatHMM(totalDay + totalNight)}</Text></View>
+            <View style={[s.cell, { flex: COLS[8][1] }]}><Text style={s.cellText}> </Text></View>
+          </View>
+        </View>
+
+        {/* Signature block */}
+        <View style={s.sigRow}>
+          <View style={s.sigBlock}>
+            <View style={s.sigLine}><Text> </Text></View>
+            <Text style={s.sigLabel}>Student Signature</Text>
+          </View>
+          <View style={s.sigBlock}>
+            <View style={s.sigLine}><Text> </Text></View>
+            <Text style={s.sigLabel}>Parent / Guardian Signature</Text>
+          </View>
+        </View>
+
+      </Page>
+    </Document>
+  );
+}

--- a/src/app/api/report/pdf/route.tsx
+++ b/src/app/api/report/pdf/route.tsx
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { renderToBuffer } from '@react-pdf/renderer';
+import { auth } from '@/auth';
+import { db } from '@/db';
+import { trips, users, type UserType } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { resolveSelectedStudentId } from '@/app/(app)/actions';
+import { ReportDocument } from './document';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const { id, userType: userTypeRaw } = session.user;
+  const userType = userTypeRaw as UserType;
+  const userId = Number(id);
+
+  let studentId: number;
+  let studentName: string | null = null;
+  let parentName: string | null = null;
+
+  if (userType === 'parent') {
+    const resolved = await resolveSelectedStudentId(userId);
+    if (!resolved) {
+      return new NextResponse('No student selected', { status: 400 });
+    }
+    studentId = resolved;
+    const [student] = await db
+      .select({ name: users.name })
+      .from(users)
+      .where(and(eq(users.id, studentId), eq(users.parentId, userId)));
+    studentName = student?.name ?? null;
+    const [parent] = await db.select({ name: users.name }).from(users).where(eq(users.id, userId));
+    parentName = parent?.name ?? null;
+  } else {
+    studentId = userId;
+    const [student] = await db.select({ name: users.name }).from(users).where(eq(users.id, userId));
+    studentName = student?.name ?? null;
+  }
+
+  const tripRows = await db
+    .select()
+    .from(trips)
+    .where(eq(trips.studentId, studentId))
+    .orderBy(trips.tripDate, trips.id);
+
+  let runningDay = 0;
+  let runningNight = 0;
+  const rows = tripRows.map((trip) => {
+    runningDay += trip.daytimeMinutes;
+    runningNight += trip.nighttimeMinutes;
+    return { ...trip, runningDay, runningNight, grandTotal: runningDay + runningNight };
+  });
+
+  const printedDate = new Date().toLocaleDateString('en-US', {
+    year: 'numeric', month: 'long', day: 'numeric',
+  });
+
+  const buffer = await renderToBuffer(
+    <ReportDocument
+      rows={rows}
+      studentName={studentName}
+      parentName={parentName}
+      totalDay={runningDay}
+      totalNight={runningNight}
+      printedDate={printedDate}
+    />
+  );
+
+  const filename = `driving-log-${studentName?.toLowerCase().replace(/\s+/g, '-') ?? 'report'}.pdf`;
+
+  return new NextResponse(new Uint8Array(buffer), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,6 +4,7 @@ import * as schema from './schema';
 
 const client = createClient({
   url: process.env.DATABASE_URL!,
+  authToken: process.env.DATABASE_AUTH_TOKEN,
 });
 
 export const db = drizzle(client, { schema });


### PR DESCRIPTION
## Summary
- `GET /api/report/pdf` — authenticated route handler; returns `application/pdf` with `Content-Disposition: attachment`
- PDF layout: landscape Letter, Illinois SOS DSD X 152.4 columns (Date, Location, Weather, Daytime, Daytime Total, Nighttime, Nighttime Total, Grand Total, Initials)
- Running totals per row, totals footer, signature lines, alternating row shading, green header
- Returns 401 for unauthenticated requests, 400 if no student is selected
- `/report` page gains "Download PDF" anchor + "Print" button side by side

## Test plan
- [ ] Visit /report, click "Download PDF" — file downloads as `driving-log-jimmy.pdf`
- [ ] Open PDF — correct columns, running totals, student name, date
- [ ] Hit `/api/report/pdf` without a session — 401 response
- [ ] Student account — PDF scoped to their own trips

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)