### PR TITLE
fix: embed Turso authToken in drizzle-kit connection URL

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from 'drizzle-kit';
 
+const url = process.env.DATABASE_URL ?? 'file:local.db';
+const authToken = process.env.DATABASE_AUTH_TOKEN;
+
 export default defineConfig({
   dialect: 'sqlite',
   schema: './src/db/schema.ts',
   out: './drizzle',
   dbCredentials: {
-    // drizzle-kit does not load .env.local; fall back to local file for dev
-    url: process.env.DATABASE_URL ?? 'file:local.db',
+    // drizzle-kit doesn't support authToken as a separate field for sqlite;
+    // embed it in the URL when connecting to Turso
+    url: authToken ? `${url}?authToken=${authToken}` : url,
   },
 });


### PR DESCRIPTION
## Summary
- `drizzle.config.ts` — drizzle-kit's sqlite dialect only accepts a `url` field in `dbCredentials`, not a separate `authToken`. Embeds the token as a query parameter (`?authToken=...`) so drizzle-kit can connect to Turso in production. Falls back to `file:local.db` unchanged when `DATABASE_AUTH_TOKEN` is unset.

Part of #13

## Test plan
- [ ] Confirm `npm run db:generate` still works locally (no token set → uses local file)
- [ ] Confirm drizzle-kit can connect to Turso in production with token set

🤖 Generated with [Claude Code](https://claude.com/claude-code)