### PR TITLE
fix: exclude apple-icon from auth middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,6 @@ export const config = {
      * - favicon.ico
      * - /login, /register (public auth pages)
      */
-    '/((?!api/auth|_next/static|_next/image|favicon.ico|login|register).*)',
+    '/((?!api/auth|_next/static|_next/image|favicon.ico|apple-icon|login|register).*)',
   ],
 };


### PR DESCRIPTION
## Summary
- The `/apple-icon` route was returning a 307 redirect to `/login`, so iOS couldn't fetch the home screen icon
- Added `apple-icon` to the middleware matcher exclusion list alongside `favicon.ico`

Closes #26

## Test plan
- [ ] Deploy and confirm `curl -sI https://student-driver-log.vercel.app/apple-icon` returns `200 image/png`
- [ ] Remove old home screen shortcut, re-add via Safari → the green steering wheel icon should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)