### PR TITLE
feat: add Google Analytics tracking

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,3 +3,6 @@ DATABASE_URL=file:local.db
 
 # Required for Auth.js — generate with: openssl rand -base64 32
 AUTH_SECRET=your-secret-here
+
+# Google Analytics 4 — leave blank or omit to disable (e.g. in local dev/CI)
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Overpass, Overpass_Mono } from 'next/font/google';
+import Script from 'next/script';
 import './globals.css';
 import { cn } from '@/lib/utils';
 import { Toaster } from '@/components/ui/sonner';
@@ -39,6 +40,22 @@ export default function RootLayout({
       style={{ colorScheme: 'light' }}
     >
       <body className="min-h-full flex flex-col">
+        {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script id="gtag-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}');
+              `}
+            </Script>
+          </>
+        )}
         {children}
         <Toaster richColors position="top-right" />
       </body>


### PR DESCRIPTION
## Summary
- Conditionally injects GA4 scripts in the root layout using `next/script` with `afterInteractive` strategy
- Scripts only render when `NEXT_PUBLIC_GA_MEASUREMENT_ID` env var is set — no GA in local dev/CI unless explicitly configured
- Adds env var placeholder to `.env.local.example`

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Set `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-V6S6KDTTD0` in `.env.local`, start dev server, confirm Network tab shows request to `googletagmanager.com`
- [ ] GA4 Real-time report shows a session after page visit
- [ ] Unset the env var, restart — confirm no GA network requests
- [ ] Add env var to Vercel production settings before next production deploy

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)