### PR TITLE
feat: add Playwright e2e test for core user journey (#11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,9 @@ yarn-error.log*
 .env*
 !.env*.example
 
-# local sqlite database
+# local sqlite databases
 local.db
+test.db
 
 # vercel
 .vercel

--- a/_bmad-output/implementation-artifacts/spec-gh-11-playwright-e2e.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-11-playwright-e2e.md
@@ -1,0 +1,25 @@
+---
+title: 'Playwright e2e — core user journey'
+type: one-shot
+created: '2026-04-26'
+status: done
+route: one-shot
+---
+
+# Playwright e2e — core user journey
+
+## Intent
+
+**Problem:** No e2e test coverage existed; Playwright was in devDependencies but unconfigured.
+
+**Approach:** Added `playwright.config.ts` (port 3001, Node.js production server, isolated `test.db`), global setup/teardown for DB lifecycle, and one test covering register → add student → log trip → verify trips list → verify report. Three non-obvious issues resolved: (1) edge-runtime libSQL rejecting `file:` URLs fixed by adding `export const runtime = 'nodejs'` to middleware; (2) Auth.js `UntrustedHost` on port 3001 fixed via `AUTH_TRUST_HOST=1` and `AUTH_URL`; (3) Next.js router-cache serving stale AppLayout (pre-student) fixed with `page.reload()` after student creation.
+
+## Suggested Review Order
+
+1. [middleware.ts](../../middleware.ts) — `runtime = 'nodejs'` export (production correctness fix)
+2. [playwright.config.ts](../../playwright.config.ts) — webServer config, env vars, port 3001
+3. [tests/e2e/global-setup.ts](../../tests/e2e/global-setup.ts) — migration against test.db
+4. [tests/e2e/global-teardown.ts](../../tests/e2e/global-teardown.ts) — cleanup
+5. [tests/e2e/core-journey.spec.ts](../../tests/e2e/core-journey.spec.ts) — the test with inline comments on non-obvious steps
+6. [package.json](../../package.json) — `test:e2e` script
+7. [.gitignore](../../.gitignore) — `test.db` added

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,9 @@
 export { auth as default } from '@/auth';
 
+// auth.ts imports @libsql/client which uses file: URLs incompatible with the
+// edge runtime's Web-API-only libSQL client. Force Node.js runtime here.
+export const runtime = 'nodejs';
+
 export const config = {
   matcher: [
     /*

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest",
+    "test:e2e": "playwright test",
     "lint": "eslint",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3001',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  globalSetup: './tests/e2e/global-setup.ts',
+  globalTeardown: './tests/e2e/global-teardown.ts',
+  webServer: {
+    // Port 3001 avoids conflict with the dev server on 3000.
+    // next build is required before running tests locally (CI does it automatically).
+    command: 'npm run build && npm start -- -p 3001',
+    url: 'http://localhost:3001',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      DATABASE_URL: 'file:./test.db',
+      DATABASE_AUTH_TOKEN: '',
+      AUTH_SECRET: 'test-secret-for-e2e-only-not-for-production',
+      AUTH_URL: 'http://localhost:3001',
+      AUTH_TRUST_HOST: '1',
+    },
+  },
+});

--- a/tests/e2e/core-journey.spec.ts
+++ b/tests/e2e/core-journey.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+// Full journey covers server startup + 6 page loads — 90s is ample.
+test.setTimeout(90_000);
+
+test('core journey: register, add student, log trip, verify trips list, view report', async ({ page }) => {
+  const ts = Date.now();
+  const parentEmail = `parent-${ts}@example.com`;
+  const studentEmail = `student-${ts}@example.com`;
+  const password = 'testpassword123';
+  const today = new Date().toISOString().split('T')[0];
+
+  // --- Register as parent ---
+  await page.goto('/register');
+  await page.locator('[name="name"]').fill('Test Parent');
+  await page.locator('[name="email"]').fill(parentEmail);
+  await page.locator('[name="password"]').fill(password);
+  await page.getByRole('button', { name: 'Create Account' }).click();
+  await expect(page).toHaveURL('/dashboard');
+
+  // --- Add a student ---
+  await page.getByRole('link', { name: '+ Add a Student' }).click();
+  await expect(page).toHaveURL('/students/new');
+  await page.locator('[name="name"]').fill('Test Student');
+  await page.locator('[name="email"]').fill(studentEmail);
+  await page.locator('[name="password"]').fill(password);
+  await page.getByRole('button', { name: 'Add Student' }).click();
+  // Wait for addStudentAction to complete and redirect to /dashboard.
+  await expect(page).toHaveURL('/dashboard', { timeout: 15_000 });
+  // The redirect uses client-side navigation which can serve a cached AppLayout
+  // (pre-student). A full reload forces the layout to re-fetch with the new student.
+  await page.reload();
+
+  // The select only appears when a student exists. Trigger selectStudentAction
+  // so the selected_student_id cookie is written before we log a trip.
+  const studentSelect = page.locator('select').first();
+  await studentSelect.waitFor({ state: 'visible', timeout: 15_000 });
+  await studentSelect.selectOption({ index: 0 });
+  await page.waitForLoadState('networkidle');
+
+  // --- Log a trip ---
+  await page.goto('/trips/new');
+  await page.locator('[name="tripDate"]').fill(today);
+  await page.locator('[name="locationType"]').selectOption('highway');
+  await page.locator('[name="weather"]').selectOption('clear');
+  await page.locator('[name="daytimeMinutes"]').fill('60');
+  await page.getByRole('button', { name: 'Log Trip' }).click();
+  await expect(page.getByText('Trip Logged')).toBeVisible();
+
+  // --- Verify trip appears in trips list ---
+  await page.goto('/trips');
+  await expect(page.getByRole('cell', { name: 'Highway' })).toBeVisible();
+
+  // --- Verify trip appears in report ---
+  await page.goto('/report');
+  await expect(page.getByRole('cell', { name: 'Highway' })).toBeVisible();
+  // 60 daytime minutes displays as 1:00 in the report table
+  await expect(page.getByRole('cell', { name: '1:00' }).first()).toBeVisible();
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,16 @@
+import { execSync } from 'child_process';
+
+export default async function globalSetup() {
+  // Clear any Turso token so drizzle-kit targets the local test file, not a remote DB
+  process.env.DATABASE_URL = 'file:./test.db';
+  process.env.DATABASE_AUTH_TOKEN = '';
+
+  execSync('npm run db:migrate', {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      DATABASE_URL: 'file:./test.db',
+      DATABASE_AUTH_TOKEN: '',
+    },
+  });
+}

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,0 +1,9 @@
+import { unlink } from 'fs/promises';
+
+export default async function globalTeardown() {
+  try {
+    await unlink('./test.db');
+  } catch {
+    // test.db may not exist if global setup failed before creating it
+  }
+}


### PR DESCRIPTION
## Summary

- Configures Playwright on port 3001 with an isolated `test.db` so e2e tests never touch `local.db` or Turso
- Global setup/teardown manages DB migration and cleanup around the suite
- One test covers the full core journey: register → add student → log trip → trips list → report
- Fixes `middleware.ts` to use Node.js runtime (edge libSQL doesn't support `file:` URLs in production builds)

## Non-obvious implementation notes

- `AUTH_TRUST_HOST=1` required because Auth.js v5 rejects localhost:3001 as untrusted in production mode
- `page.reload()` after adding a student bypasses the Next.js router cache, which otherwise serves a stale AppLayout with 0 students
- `selectOption({ index: 0 })` on the nav dropdown triggers `selectStudentAction`, writing the `selected_student_id` cookie that `createTripAction` requires

## Test plan

- [ ] `npm run test:e2e` passes locally (requires `npm run build` first)
- [ ] CI run passes (triggered by this PR)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)