### PR TITLE
chore: add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 John Telford
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_bmad-output/implementation-artifacts/spec-gh-45-license-file.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-45-license-file.md
@@ -1,0 +1,17 @@
+---
+title: 'Add MIT LICENSE file'
+type: 'chore'
+created: '2026-04-26'
+status: 'done'
+route: 'one-shot'
+---
+
+## Intent
+
+**Problem:** The repository had no LICENSE file, leaving its terms unclear to anyone who finds it on GitHub.
+
+**Approach:** Add a standard MIT License file at the repo root with copyright holder John Telford, year 2026.
+
+## Suggested Review Order
+
+- [LICENSE](../../LICENSE) — canonical MIT text; verify copyright line


### PR DESCRIPTION
## Summary
- Adds canonical MIT License at the repo root with copyright holder John Telford, 2026
- GitHub will now display the license on the repository home page

## Test plan
- [ ] Visit the GitHub repo home page and confirm the MIT license badge/link appears

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)