### PR TITLE
feat: add styled 404 and 500 error pages

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function Error({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white">
+      <div className="p-[6px] bg-white rounded-3xl shadow-lg border-[3px] border-black w-full max-w-sm">
+        <div className="bg-primary rounded-[1.2rem] px-8 py-10 space-y-6 text-center">
+          <div className="space-y-2">
+            <p className="text-accent font-black text-8xl tracking-tight leading-none">500</p>
+            <h1 className="text-white font-black text-xl uppercase tracking-widest">
+              Unexpected Detour
+            </h1>
+            <p className="text-white/60 text-sm">
+              Something went wrong on our end.
+            </p>
+            {error.digest && (
+              <p className="text-white/40 text-xs font-mono">ref: {error.digest}</p>
+            )}
+          </div>
+          <div className="flex flex-col gap-3 items-center">
+            <button
+              onClick={unstable_retry}
+              className="rounded bg-accent px-6 py-2.5 text-sm font-black text-accent-foreground uppercase tracking-widest hover:opacity-90"
+            >
+              Try Again
+            </button>
+            <Link
+              href="/dashboard"
+              className="text-white/60 text-xs uppercase tracking-widest hover:text-white"
+            >
+              Go to Dashboard
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+// global-error replaces the root layout entirely — must include html+body,
+// and cannot use Tailwind design tokens. Inline styles are intentional here.
+export default function GlobalError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          background: '#ffffff',
+          fontFamily: 'sans-serif',
+          display: 'flex',
+          minHeight: '100vh',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <div
+          style={{
+            padding: 6,
+            background: '#ffffff',
+            borderRadius: 24,
+            boxShadow: '0 4px 24px rgba(0,0,0,0.12)',
+            border: '3px solid #111111',
+            width: '100%',
+            maxWidth: 380,
+          }}
+        >
+          <div
+            style={{
+              background: '#006B3C',
+              borderRadius: '1.1rem',
+              padding: '2.5rem 2rem',
+              textAlign: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '1.5rem',
+              alignItems: 'center',
+            }}
+          >
+            <div>
+              <p style={{ color: '#FFCD00', fontSize: 72, fontWeight: 900, margin: 0, lineHeight: 1 }}>
+                500
+              </p>
+              <h1
+                style={{
+                  color: '#ffffff',
+                  fontSize: 18,
+                  fontWeight: 900,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.1em',
+                  margin: '0.5rem 0',
+                }}
+              >
+                Unexpected Detour
+              </h1>
+              <p style={{ color: 'rgba(255,255,255,0.6)', fontSize: 14, margin: 0 }}>
+                Something went wrong on our end.
+              </p>
+              {error.digest && (
+                <p style={{ color: 'rgba(255,255,255,0.35)', fontSize: 11, fontFamily: 'monospace', marginTop: '0.5rem' }}>
+                  ref: {error.digest}
+                </p>
+              )}
+            </div>
+            <button
+              onClick={unstable_retry}
+              style={{
+                background: '#FFCD00',
+                color: '#111111',
+                border: 'none',
+                borderRadius: 6,
+                padding: '10px 24px',
+                fontSize: 13,
+                fontWeight: 900,
+                textTransform: 'uppercase',
+                letterSpacing: '0.12em',
+                cursor: 'pointer',
+              }}
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import { auth } from '@/auth';
+
+export default async function NotFound() {
+  const session = await auth();
+  const href = session?.user ? '/dashboard' : '/login';
+  const label = session?.user ? 'Go to Dashboard' : 'Go to Login';
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white">
+      <div className="p-[6px] bg-white rounded-3xl shadow-lg border-[3px] border-black w-full max-w-sm">
+        <div className="bg-primary rounded-[1.2rem] px-8 py-10 space-y-6 text-center">
+          <div className="space-y-2">
+            <p className="text-accent font-black text-8xl tracking-tight leading-none">404</p>
+            <h1 className="text-white font-black text-xl uppercase tracking-widest">
+              Road Not Found
+            </h1>
+            <p className="text-white/60 text-sm">
+              This destination doesn't exist on our map.
+            </p>
+          </div>
+          <Link
+            href={href}
+            className="inline-block rounded bg-accent px-6 py-2.5 text-sm font-black text-accent-foreground uppercase tracking-widest hover:opacity-90"
+          >
+            {label}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `not-found.tsx` — highway sign styled 404; links to /dashboard if logged in, /login otherwise
- `error.tsx` — client component 500 page with digest ref and Try Again button
- `global-error.tsx` — root layout error boundary with inline styles (required by Next.js — must own `<html><body>`)

## Test plan
- [ ] Navigate to a non-existent URL → styled 404 page appears
- [ ] Logged-in user sees "Go to Dashboard" link; logged-out user sees "Go to Login"
- [ ] Server error triggers `error.tsx` with Try Again button (no stack trace)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)