### PR TITLE
feat: show build version in app footer

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -56,6 +56,16 @@ export default async function AppLayout({
       <main className="flex-1 max-w-4xl w-full mx-auto px-4 py-8">
         {children}
       </main>
+
+      {(process.env.NEXT_PUBLIC_APP_VERSION || process.env.NEXT_PUBLIC_GIT_SHA) && (
+        <footer className="py-3 text-center">
+          <span className="text-xs text-black/30 font-mono">
+            {process.env.NEXT_PUBLIC_APP_VERSION && `v${process.env.NEXT_PUBLIC_APP_VERSION}`}
+            {process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_GIT_SHA && ' · '}
+            {process.env.NEXT_PUBLIC_GIT_SHA && process.env.NEXT_PUBLIC_GIT_SHA.slice(0, 7)}
+          </span>
+        </footer>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a footer to the authenticated layout showing `v{NEXT_PUBLIC_APP_VERSION} · {sha[:7]}`
- Hidden when neither env var is set (no empty footer in dev)

## Vercel setup needed
Set these in Vercel environment variables:
- `NEXT_PUBLIC_APP_VERSION` = `1.1.0` (update per release)
- `NEXT_PUBLIC_GIT_SHA` = `$VERCEL_GIT_COMMIT_SHA` (reference Vercel system env var)

## Test plan
- [ ] With env vars set, version appears in footer on all authenticated pages
- [ ] Without env vars (local dev default), footer is not rendered

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)