### PR TITLE
feat: add account deletion on settings page

### DIFF
--- a/src/app/(app)/app-nav.tsx
+++ b/src/app/(app)/app-nav.tsx
@@ -28,6 +28,11 @@ export default function AppNav({
         <Link href="/report" className="text-white/80 text-xs font-bold uppercase tracking-widest hover:text-white">
           Report
         </Link>
+        {userType === 'parent' && (
+          <Link href="/settings" className="text-white/80 text-xs font-bold uppercase tracking-widest hover:text-white">
+            Settings
+          </Link>
+        )}
         {canLogTrip && (
           <Link href="/trips/new" className="rounded bg-accent px-3 py-1 text-xs font-black text-accent-foreground uppercase tracking-widest hover:opacity-90">
             + Log Trip
@@ -71,6 +76,11 @@ export default function AppNav({
             <Link href="/report" className="text-white text-sm font-bold uppercase tracking-widest">
               Report
             </Link>
+            {userType === 'parent' && (
+              <Link href="/settings" className="text-white text-sm font-bold uppercase tracking-widest">
+                Settings
+              </Link>
+            )}
             {canLogTrip && (
               <Link href="/trips/new" className="self-start rounded bg-accent px-4 py-2 text-sm font-black text-accent-foreground uppercase tracking-widest">
                 + Log Trip

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -1,0 +1,29 @@
+'use server';
+
+import { auth, signOut } from '@/auth';
+import { db } from '@/db';
+import { users } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+
+export type DeleteAccountState = { error: string } | undefined;
+
+export async function deleteAccountAction(
+  _prev: DeleteAccountState,
+  formData: FormData
+): Promise<DeleteAccountState> {
+  const session = await auth();
+  if (!session?.user?.id || session.user.userType !== 'parent') {
+    return { error: 'Not authorized.' };
+  }
+
+  const confirm = formData.get('confirm') as string;
+  if (confirm !== 'DELETE') {
+    return { error: 'Type DELETE exactly to confirm.' };
+  }
+
+  await db.delete(users).where(eq(users.id, Number(session.user.id)));
+
+  // Cascade deletes all student accounts and their trips.
+  // signOut redirects — throws NEXT_REDIRECT, which propagates normally.
+  await signOut({ redirectTo: '/register' });
+}

--- a/src/app/(app)/settings/delete-account-form.tsx
+++ b/src/app/(app)/settings/delete-account-form.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import { useActionState } from 'react';
+import { deleteAccountAction } from './actions';
+
+export default function DeleteAccountForm() {
+  const [state, action, pending] = useActionState(deleteAccountAction, undefined);
+  const [confirmText, setConfirmText] = useState('');
+
+  return (
+    <form action={action} className="space-y-4">
+      <div>
+        <label
+          htmlFor="confirm"
+          className="block text-sm font-bold text-destructive uppercase tracking-widest mb-1"
+        >
+          Type DELETE to confirm
+        </label>
+        <input
+          id="confirm"
+          name="confirm"
+          type="text"
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value)}
+          placeholder="DELETE"
+          autoComplete="off"
+          className="w-full max-w-xs rounded border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm focus:border-destructive focus:outline-none focus:ring-1 focus:ring-destructive"
+        />
+      </div>
+
+      {state?.error && (
+        <p className="text-sm font-semibold text-destructive">{state.error}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={confirmText !== 'DELETE' || pending}
+        className="rounded bg-destructive px-5 py-2.5 text-sm font-black text-white uppercase tracking-widest hover:bg-destructive/90 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {pending ? 'Deleting…' : 'Delete My Account'}
+      </button>
+    </form>
+  );
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,30 @@
+import { auth } from '@/auth';
+import { redirect } from 'next/navigation';
+import DeleteAccountForm from './delete-account-form';
+
+export default async function SettingsPage() {
+  const session = await auth();
+  if (session?.user?.userType !== 'parent') redirect('/dashboard');
+
+  return (
+    <div className="max-w-lg space-y-8">
+      <h1 className="text-2xl font-black uppercase tracking-widest text-primary">
+        Settings
+      </h1>
+
+      <section className="rounded-lg border-2 border-destructive/40 p-6 space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-black text-destructive uppercase tracking-wide">
+            Danger Zone
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Permanently deletes your account, all student accounts, and every
+            trip record. <strong>This cannot be undone.</strong>
+          </p>
+        </div>
+
+        <DeleteAccountForm />
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/settings` page (parents only — students are redirected to /dashboard)
- Danger zone with confirm input: user must type `DELETE` exactly
- Server action deletes parent account; cascade removes all student accounts and trips
- Signs out and redirects to `/register` after deletion
- Settings link added to nav (desktop + mobile) for parent accounts

## Test plan
- [ ] Parent can reach /settings via nav
- [ ] Student visiting /settings is redirected to /dashboard
- [ ] Delete button stays disabled until `DELETE` is typed exactly
- [ ] Confirming deletion removes parent + students + trips and redirects to /register
- [ ] Typing anything other than `DELETE` returns a server-side error

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)