### PR TITLE
feat: add Open Graph and Twitter Card meta tags

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,8 +19,20 @@ const overpassMono = Overpass_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL ??
+      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  ),
   title: 'Student Driver Log',
-  description: "Illinois learner's permit hour tracker",
+  description: 'Track Illinois learner\'s permit practice hours. Free tool for families.',
+  openGraph: {
+    title: 'Student Driver Log',
+    description: 'Track Illinois learner\'s permit practice hours. Free tool for families.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+  },
   appleWebApp: {
     capable: true,
     title: 'Student Driver Log',

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 1200,
+          height: 630,
+          background: '#006B3C',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 32,
+          padding: 60,
+        }}
+      >
+        {/* Steering wheel */}
+        <svg width="160" height="160" viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="44" fill="none" stroke="white" strokeWidth="8" />
+          <line x1="50" y1="6" x2="50" y2="34" stroke="white" strokeWidth="7" strokeLinecap="round" />
+          <line x1="50" y1="66" x2="50" y2="94" stroke="white" strokeWidth="7" strokeLinecap="round" />
+          <line x1="6" y1="50" x2="34" y2="50" stroke="white" strokeWidth="7" strokeLinecap="round" />
+          <line x1="66" y1="50" x2="94" y2="50" stroke="white" strokeWidth="7" strokeLinecap="round" />
+          <circle cx="50" cy="50" r="9" fill="white" />
+        </svg>
+
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              color: '#ffffff',
+              fontSize: 72,
+              fontWeight: 900,
+              letterSpacing: '-0.01em',
+              textAlign: 'center',
+              lineHeight: 1,
+            }}
+          >
+            Student Driver Log
+          </div>
+          <div
+            style={{
+              color: '#FFCD00',
+              fontSize: 32,
+              fontWeight: 600,
+              textAlign: 'center',
+              letterSpacing: '0.02em',
+            }}
+          >
+            Track Illinois learner's permit practice hours
+          </div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `og:title`, `og:description`, `og:type`, `og:image`, `twitter:card` to root layout
- OG image (1200×630) generated via `opengraph-image.tsx` — green background, steering wheel, title + subtitle in yellow
- `metadataBase` resolves from `NEXT_PUBLIC_APP_URL` → `VERCEL_URL` → localhost fallback

## Vercel setup needed
Set `NEXT_PUBLIC_APP_URL` to your production domain (e.g. `https://student-driver-log.vercel.app`) so OG image URLs are stable across preview/production deployments.

## Test plan
- [ ] Paste app URL into [opengraph.xyz](https://www.opengraph.xyz) — title, description, and image appear
- [ ] Twitter card shows `summary_large_image` type

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)