### PR TITLE
feat: add login rate limiting (5 failed attempts / IP / 15 min)

### DIFF
--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -1,7 +1,9 @@
 'use server';
 
 import { AuthError } from 'next-auth';
+import { headers } from 'next/headers';
 import { signIn } from '@/auth';
+import { isRateLimited, recordFailure, clearFailures } from '@/lib/rate-limit';
 
 export type LoginState = { error: string } | undefined;
 
@@ -9,14 +11,23 @@ export async function loginAction(
   _prev: LoginState,
   formData: FormData
 ): Promise<LoginState> {
+  const hdrs = await headers();
+  const ip = (hdrs.get('x-forwarded-for') ?? '127.0.0.1').split(',')[0].trim();
+
+  if (isRateLimited(ip)) {
+    return { error: 'Too many login attempts. Please try again in a few minutes.' };
+  }
+
   try {
     await signIn('credentials', {
       email: formData.get('email'),
       password: formData.get('password'),
       redirectTo: '/dashboard',
     });
+    clearFailures(ip);
   } catch (error) {
     if (error instanceof AuthError) {
+      recordFailure(ip);
       return { error: 'Invalid email or password.' };
     }
     throw error;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,33 @@
+// In-memory rate limiter — persists within a serverless instance lifetime.
+// Acceptable for a low-traffic personal app; not suitable for high-volume services.
+
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const MAX_FAILURES = 5;
+
+interface Entry {
+  count: number;
+  windowStart: number;
+}
+
+const store = new Map<string, Entry>();
+
+export function isRateLimited(key: string): boolean {
+  const now = Date.now();
+  const entry = store.get(key);
+  if (!entry || now - entry.windowStart >= WINDOW_MS) return false;
+  return entry.count >= MAX_FAILURES;
+}
+
+export function recordFailure(key: string): void {
+  const now = Date.now();
+  const entry = store.get(key);
+  if (!entry || now - entry.windowStart >= WINDOW_MS) {
+    store.set(key, { count: 1, windowStart: now });
+  } else {
+    entry.count++;
+  }
+}
+
+export function clearFailures(key: string): void {
+  store.delete(key);
+}


### PR DESCRIPTION
## Summary
- Module-scoped in-memory store in `src/lib/rate-limit.ts`
- Only **failed** login attempts count; counter clears on successful login
- Rate-limited IP gets: `"Too many login attempts. Please try again in a few minutes."`
- IP read from `x-forwarded-for` header (set by Vercel)

## Trade-off note
In-memory store resets on serverless cold start. This is intentional — appropriate for a low-traffic personal app. A Redis-backed solution (Upstash) would be needed for production-scale protection.

## Test plan
- [ ] 5 failed logins from same IP → 6th attempt returns rate limit error without processing credentials
- [ ] Successful login after failures clears the counter

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)