### PR TITLE
feat: add PWA manifest with standalone mode and theme color

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Student Driver Log',
+    short_name: 'Driver Log',
+    description: "Track Illinois learner's permit practice hours",
+    start_url: '/dashboard',
+    display: 'standalone',
+    orientation: 'portrait',
+    theme_color: '#006B3C',
+    background_color: '#006B3C',
+    icons: [
+      {
+        src: '/icon',
+        sizes: '32x32',
+        type: 'image/png',
+      },
+      {
+        src: '/apple-icon',
+        sizes: '180x180',
+        type: 'image/png',
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- Creates `src/app/manifest.ts` (Next.js `MetadataRoute.Manifest`)
- Sets: `theme_color` + `background_color` = `#006B3C`, `display: standalone`, `start_url: /dashboard`, `orientation: portrait`

## Test plan
- [ ] Add to iOS home screen → app opens in standalone mode (no browser chrome)
- [ ] Status bar / splash shows green theme color

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)