### PR TITLE
feat: show build version in app footer

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,8 @@
 import type { NextConfig } from 'next';
 import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8'));
+const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
 
 function getGitSha(): string {
   if (process.env.VERCEL_GIT_COMMIT_SHA) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,30 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8'));
+
+function getGitSha(): string {
+  if (process.env.VERCEL_GIT_COMMIT_SHA) {
+    return process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7);
+  }
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['pipe', 'pipe', 'pipe'] })
+      .toString()
+      .trim();
+  } catch {
+    return 'dev';
+  }
+}
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+    NEXT_PUBLIC_GIT_SHA: getGitSha(),
+  },
 };
 
 export default nextConfig;

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -56,6 +56,16 @@ export default async function AppLayout({
       <main className="flex-1 max-w-4xl w-full mx-auto px-4 py-8">
         {children}
       </main>
+
+      {(process.env.NEXT_PUBLIC_APP_VERSION || process.env.NEXT_PUBLIC_GIT_SHA) && (
+        <footer className="py-3 text-center">
+          <span className="text-xs text-black/30 font-mono">
+            {process.env.NEXT_PUBLIC_APP_VERSION && `v${process.env.NEXT_PUBLIC_APP_VERSION}`}
+            {process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_GIT_SHA && ' · '}
+            {process.env.NEXT_PUBLIC_GIT_SHA && process.env.NEXT_PUBLIC_GIT_SHA.slice(0, 7)}
+          </span>
+        </footer>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a footer to the authenticated layout showing `v{version} · {sha[:7]}`
- Version and SHA are injected at build time via `next.config.ts` — no manual env vars needed
- `NEXT_PUBLIC_APP_VERSION` reads from `package.json`
- `NEXT_PUBLIC_GIT_SHA` uses `VERCEL_GIT_COMMIT_SHA` on Vercel, falls back to `git rev-parse --short HEAD` locally
- Footer is hidden when neither value is available (edge case only)

## Test plan
- [ ] After merging and deploying, log in and check the footer on /dashboard
- [ ] Version string shows `v0.1.0 · <7-char sha>`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)