### PR TITLE
feat: add About, Privacy, Terms, and FAQ pages

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,8 @@ export const config = {
      * - _next/static, _next/image (Next.js internals)
      * - favicon.ico
      * - /login, /register, /forgot-password, /reset-password (public auth pages)
+     * - /about, /privacy, /terms, /faq (public info pages)
      */
-    '/((?!api/auth|_next/static|_next/image|favicon.ico|icon|apple-icon|login|register|forgot-password|reset-password).*)',
+    '/((?!api/auth|_next/static|_next/image|favicon.ico|icon|apple-icon|login|register|forgot-password|reset-password|about|privacy|terms|faq).*)',
   ],
 };

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -57,15 +57,23 @@ export default async function AppLayout({
         {children}
       </main>
 
-      {(process.env.NEXT_PUBLIC_APP_VERSION || process.env.NEXT_PUBLIC_GIT_SHA) && (
-        <footer className="py-3 text-center">
-          <span className="text-xs text-black/30 font-mono">
-            {process.env.NEXT_PUBLIC_APP_VERSION && `v${process.env.NEXT_PUBLIC_APP_VERSION}`}
-            {process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_GIT_SHA && ' · '}
-            {process.env.NEXT_PUBLIC_GIT_SHA && process.env.NEXT_PUBLIC_GIT_SHA.slice(0, 7)}
-          </span>
-        </footer>
-      )}
+      <footer className="border-t border-black/10 py-4 mt-4">
+        <div className="max-w-4xl mx-auto px-4 flex flex-wrap items-center gap-4">
+          <div className="flex gap-4 text-[10px] text-black/40 uppercase tracking-widest">
+            <Link href="/about" className="hover:text-black/70">About</Link>
+            <Link href="/privacy" className="hover:text-black/70">Privacy</Link>
+            <Link href="/terms" className="hover:text-black/70">Terms</Link>
+            <Link href="/faq" className="hover:text-black/70">FAQ</Link>
+          </div>
+          {(process.env.NEXT_PUBLIC_APP_VERSION || process.env.NEXT_PUBLIC_GIT_SHA) && (
+            <span className="ml-auto text-xs text-black/30 font-mono">
+              {process.env.NEXT_PUBLIC_APP_VERSION && `v${process.env.NEXT_PUBLIC_APP_VERSION}`}
+              {process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_GIT_SHA && ' · '}
+              {process.env.NEXT_PUBLIC_GIT_SHA && process.env.NEXT_PUBLIC_GIT_SHA.slice(0, 7)}
+            </span>
+          )}
+        </div>
+      </footer>
     </div>
   );
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -119,12 +119,20 @@ export default function LoginPage() {
           </form>
 
           {/* Footer */}
-          <p className="text-center text-[10px] text-white/50 uppercase tracking-widest border-t border-white/20 pt-4">
-            Need an account?{' '}
-            <Link href="/register" className="text-accent font-bold hover:opacity-80">
-              Register
-            </Link>
-          </p>
+          <div className="space-y-3 border-t border-white/20 pt-4">
+            <p className="text-center text-[10px] text-white/50 uppercase tracking-widest">
+              Need an account?{' '}
+              <Link href="/register" className="text-accent font-bold hover:opacity-80">
+                Register
+              </Link>
+            </p>
+            <div className="flex justify-center gap-4 text-[10px] text-white/30 uppercase tracking-widest">
+              <Link href="/about" className="hover:text-white/60">About</Link>
+              <Link href="/privacy" className="hover:text-white/60">Privacy</Link>
+              <Link href="/terms" className="hover:text-white/60">Terms</Link>
+              <Link href="/faq" className="hover:text-white/60">FAQ</Link>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'About — Student Driver Log',
+};
+
+export default function AboutPage() {
+  return (
+    <div className="space-y-8 text-sm leading-relaxed text-black/80">
+
+      <div className="space-y-2">
+        <h1 className="text-2xl font-black uppercase tracking-widest text-primary">About</h1>
+        <p className="text-black/40 text-xs uppercase tracking-widest">Student Driver Log</p>
+      </div>
+
+      <section className="space-y-4">
+        <p>
+          Student Driver Log started as a personal itch. When my son was working toward his Illinois
+          driver's license, we needed to log 50 hours of supervised driving — and the spreadsheet
+          we were using wasn't cutting it. So I built something better.
+        </p>
+        <p>
+          There are other apps that do this. This one is mine, and now yours too if it's useful.
+          It's free, it runs in your browser, and it installs on your phone's home screen without
+          any app store involved.
+        </p>
+        <p>
+          It's also a small demonstration of something I find genuinely exciting: people with a
+          technical background can build real, production-quality software faster than ever before —
+          with AI as a collaborator rather than just a tool. This app was built almost entirely
+          with AI assistance, from the database schema to the authentication system to the PDF
+          report generator. If you're curious about that process, the code is open on GitHub.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">What it does</h2>
+        <ul className="space-y-2 list-none">
+          {[
+            'Tracks daytime and nighttime driving hours for each session',
+            'Supports multiple student accounts under one parent login',
+            'Generates a printable report matching Illinois SOS Form DSD X 152.4',
+            'Works as an installable app on iOS and Android home screens',
+            'Free — no subscriptions, no ads, no account required beyond your own login',
+          ].map((item) => (
+            <li key={item} className="flex gap-3">
+              <span className="text-accent font-black shrink-0">→</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Feedback & issues</h2>
+        <p>
+          Found a bug? Have a suggestion? The project is open source.{' '}
+          <a
+            href="https://github.com/john-telford/student-driver-log"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary font-bold underline underline-offset-2 hover:opacity-70"
+          >
+            Open an issue on GitHub
+          </a>{' '}
+          and I'll take a look.
+        </p>
+      </section>
+
+    </div>
+  );
+}

--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -1,0 +1,139 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'FAQ — Student Driver Log',
+};
+
+function Q({ children }: { children: React.ReactNode }) {
+  return <h2 className="font-black uppercase tracking-widest text-primary">{children}</h2>;
+}
+
+function A({ children }: { children: React.ReactNode }) {
+  return <div className="space-y-2 text-sm leading-relaxed text-black/80">{children}</div>;
+}
+
+export default function FaqPage() {
+  return (
+    <div className="space-y-8">
+
+      <div className="space-y-2">
+        <h1 className="text-2xl font-black uppercase tracking-widest text-primary">FAQ</h1>
+        <p className="text-black/40 text-xs uppercase tracking-widest">Frequently Asked Questions</p>
+      </div>
+
+      {/* ── iOS home screen ── */}
+      <section className="space-y-3">
+        <Q>How do I add this to my iPhone home screen?</Q>
+        <A>
+          <p>Student Driver Log works as an installable app on iOS — no App Store required.</p>
+          <ol className="space-y-1 list-decimal list-inside">
+            <li>Open <span className="font-bold">studentdriver.site</span> in Safari (must be Safari, not Chrome).</li>
+            <li>Tap the <span className="font-bold">Share</span> button at the bottom of the screen (the box with an arrow pointing up).</li>
+            <li>Scroll down and tap <span className="font-bold">Add to Home Screen</span>.</li>
+            <li>Tap <span className="font-bold">Add</span> in the top right corner.</li>
+          </ol>
+          <p>The app icon will appear on your home screen and launch fullscreen — no browser chrome.</p>
+        </A>
+      </section>
+
+      {/* ── Android home screen ── */}
+      <section className="space-y-3">
+        <Q>How do I add this to my Android home screen?</Q>
+        <A>
+          <ol className="space-y-1 list-decimal list-inside">
+            <li>Open <span className="font-bold">studentdriver.site</span> in Chrome.</li>
+            <li>Tap the three-dot menu in the top right.</li>
+            <li>Tap <span className="font-bold">Add to Home screen</span>.</li>
+            <li>Tap <span className="font-bold">Add</span> to confirm.</li>
+          </ol>
+          <p>The app launches fullscreen from your home screen, just like a native app.</p>
+        </A>
+      </section>
+
+      {/* ── Forgot password ── */}
+      <section className="space-y-3">
+        <Q>I forgot my password. How do I reset it?</Q>
+        <A>
+          <ol className="space-y-1 list-decimal list-inside">
+            <li>Go to the <Link href="/login" className="text-primary font-bold underline underline-offset-2 hover:opacity-70">Sign In</Link> page.</li>
+            <li>Click <span className="font-bold">Forgot?</span> next to the Password field.</li>
+            <li>Enter your email address and click <span className="font-bold">Send Reset Link</span>.</li>
+            <li>Check your inbox (and spam folder) for an email from Student Driver Log.</li>
+            <li>Click the link in the email and enter a new password.</li>
+          </ol>
+          <p>Reset links expire after 1 hour and can only be used once.</p>
+        </A>
+      </section>
+
+      {/* ── Illinois hours ── */}
+      <section className="space-y-3">
+        <Q>What are the Illinois driving hour requirements?</Q>
+        <A>
+          <p>
+            Based on our best understanding, Illinois requires student drivers to complete{' '}
+            <span className="font-bold">50 total hours</span> of supervised driving practice,
+            including at least <span className="font-bold">10 hours at night</span>, before
+            taking the road test.
+          </p>
+          <p className="text-black/60 text-xs border-l-2 border-accent pl-3">
+            <span className="font-bold">Important:</span> Requirements can change. Always verify
+            the current rules with the{' '}
+            <a
+              href="https://www.ilsos.gov/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary font-bold underline underline-offset-2 hover:opacity-70"
+            >
+              Illinois Secretary of State
+            </a>{' '}
+            before relying on this information for any official purpose. Use this app at your own risk.
+          </p>
+        </A>
+      </section>
+
+      {/* ── Add a student ── */}
+      <section className="space-y-3">
+        <Q>How do I add a student?</Q>
+        <A>
+          <ol className="space-y-1 list-decimal list-inside">
+            <li>Sign in to your <span className="font-bold">parent account</span>.</li>
+            <li>From the dashboard, click <span className="font-bold">Add Student</span>.</li>
+            <li>Enter the student's name and a login email and password for their account.</li>
+            <li>Click <span className="font-bold">Add Student</span> to save.</li>
+          </ol>
+          <p>The student can then log in separately with their own credentials to view their hours.</p>
+        </A>
+      </section>
+
+      {/* ── Switch students ── */}
+      <section className="space-y-3">
+        <Q>How do I switch between students?</Q>
+        <A>
+          <p>
+            If you have more than one student, a student selector appears in the top navigation bar.
+            Click it to switch — the dashboard and trip log will update to show the selected
+            student's data.
+          </p>
+        </A>
+      </section>
+
+      {/* ── Still have questions ── */}
+      <section className="pt-4 border-t border-black/10 space-y-2">
+        <p className="text-sm text-black/60">
+          Still have a question?{' '}
+          <a
+            href="https://github.com/john-telford/student-driver-log"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary font-bold underline underline-offset-2 hover:opacity-70"
+          >
+            Open an issue on GitHub
+          </a>
+          .
+        </p>
+      </section>
+
+    </div>
+  );
+}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+
+export default function PublicLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      <header className="bg-primary border-b-4 border-accent">
+        <div className="max-w-3xl mx-auto px-6 h-14 flex items-center">
+          <Link
+            href="/login"
+            className="text-white font-black text-sm uppercase tracking-widest hover:opacity-80"
+          >
+            Student Driver Log
+          </Link>
+        </div>
+      </header>
+      <main className="flex-1 max-w-3xl mx-auto w-full px-6 py-12">
+        {children}
+      </main>
+      <footer className="border-t border-black/10 py-6">
+        <div className="max-w-3xl mx-auto px-6 flex flex-wrap gap-4 text-xs text-black/40 uppercase tracking-widest">
+          <Link href="/about" className="hover:text-black/70">About</Link>
+          <Link href="/privacy" className="hover:text-black/70">Privacy</Link>
+          <Link href="/terms" className="hover:text-black/70">Terms</Link>
+          <Link href="/faq" className="hover:text-black/70">FAQ</Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — Student Driver Log',
+};
+
+const EFFECTIVE_DATE = 'April 27, 2026';
+
+export default function PrivacyPage() {
+  return (
+    <div className="space-y-8 text-sm leading-relaxed text-black/80">
+
+      <div className="space-y-2">
+        <h1 className="text-2xl font-black uppercase tracking-widest text-primary">Privacy Policy</h1>
+        <p className="text-black/40 text-xs uppercase tracking-widest">Effective {EFFECTIVE_DATE}</p>
+      </div>
+
+      <p>
+        Student Driver Log is a free, personal project. This policy explains what data is collected,
+        how it's used, and what your options are. Plain English throughout.
+      </p>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">What we collect</h2>
+        <ul className="space-y-2">
+          <li><span className="font-bold">Account data</span> — your name and email address when you register.</li>
+          <li><span className="font-bold">Password</span> — stored as a one-way hash (bcrypt). We cannot read your password.</li>
+          <li><span className="font-bold">Driving sessions</span> — date, duration (day/night minutes), location type, weather conditions, and optional notes that you enter.</li>
+          <li><span className="font-bold">Student accounts</span> — names and emails of student accounts you create as a parent.</li>
+          <li><span className="font-bold">Session cookies</span> — used to keep you logged in (8-hour expiry). A separate cookie remembers which student account you last selected.</li>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Analytics</h2>
+        <p>
+          This site uses <span className="font-bold">Google Analytics 4</span> to understand aggregate
+          usage patterns (page views, general traffic). Google Analytics collects your IP address and
+          browser information. You can opt out using the{' '}
+          <a
+            href="https://tools.google.com/dlpage/gaoptout"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary font-bold underline underline-offset-2 hover:opacity-70"
+          >
+            Google Analytics Opt-out Browser Add-on
+          </a>
+          .
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Third-party services</h2>
+        <p>Your data passes through these services to run the app:</p>
+        <ul className="space-y-2">
+          <li><span className="font-bold">Vercel</span> — hosting and serving the application.</li>
+          <li><span className="font-bold">Turso</span> — the database where your account and driving log data is stored.</li>
+          <li><span className="font-bold">Resend</span> — sends password reset emails on your request. Your email address is transmitted to Resend only when a reset is initiated.</li>
+        </ul>
+        <p>No data is sold to third parties. Ever.</p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Data retention & deletion</h2>
+        <p>
+          Your data is kept for as long as your account exists. You can permanently delete your
+          account — including all student accounts and every driving session — from{' '}
+          <span className="font-bold">Settings → Delete Account</span> inside the app. Deletion is
+          immediate and irreversible.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Questions</h2>
+        <p>
+          For privacy-related questions or requests,{' '}
+          <a
+            href="https://github.com/john-telford/student-driver-log"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary font-bold underline underline-offset-2 hover:opacity-70"
+          >
+            open an issue on GitHub
+          </a>
+          . This app is governed by the laws of the State of Illinois, USA.
+        </p>
+      </section>
+
+    </div>
+  );
+}

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Terms of Use — Student Driver Log',
+};
+
+const EFFECTIVE_DATE = 'April 27, 2026';
+
+export default function TermsPage() {
+  return (
+    <div className="space-y-8 text-sm leading-relaxed text-black/80">
+
+      <div className="space-y-2">
+        <h1 className="text-2xl font-black uppercase tracking-widest text-primary">Terms of Use</h1>
+        <p className="text-black/40 text-xs uppercase tracking-widest">Effective {EFFECTIVE_DATE}</p>
+      </div>
+
+      <p>
+        By using Student Driver Log you agree to these terms. They're short and in plain English.
+      </p>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">What this app is</h2>
+        <p>
+          Student Driver Log is a free, personal tool to help families track supervised driving
+          hours. It is not affiliated with the Illinois Secretary of State, the Illinois Department
+          of Transportation, or any government agency. It is not legal advice.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">No warranty</h2>
+        <p>
+          This app is provided <span className="font-bold">as-is</span>, free of charge, with no
+          guarantees. We make no warranty that the hour calculations, report formats, or
+          requirements information are accurate, complete, or current. Illinois driving requirements
+          can change — always verify with the{' '}
+          <a
+            href="https://www.ilsos.gov/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary font-bold underline underline-offset-2 hover:opacity-70"
+          >
+            Illinois Secretary of State
+          </a>{' '}
+          before relying on this app for any official purpose.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Your responsibility</h2>
+        <p>
+          You are responsible for the accuracy of the data you enter. This app records what you
+          tell it. It cannot verify that driving sessions actually occurred.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Limitation of liability</h2>
+        <p>
+          To the fullest extent permitted by law, the creator of this app is not liable for any
+          damages arising from its use — including but not limited to reliance on inaccurate hour
+          counts or report formats.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Service availability</h2>
+        <p>
+          This is a personal project. The service may be changed, paused, or discontinued at any
+          time without notice. Export or print your report before you need it.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Governing law</h2>
+        <p>These terms are governed by the laws of the State of Illinois, USA.</p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-black uppercase tracking-widest text-primary">Questions</h2>
+        <p>
+          <a
+            href="https://github.com/john-telford/student-driver-log"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary font-bold underline underline-offset-2 hover:opacity-70"
+          >
+            Open an issue on GitHub
+          </a>{' '}
+          with any questions or concerns.
+        </p>
+      </section>
+
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Four public content pages with a shared `(public)` layout (green header, nav footer). All accessible without login. Footer links added to the authenticated app layout.

- **`/about`** — Origin story, what the app does, GitHub link
- **`/privacy`** — Data collected, GA4 disclosure, Turso/Vercel/Resend third parties, deletion via Settings
- **`/terms`** — Plain English: no warranty, verify with IL SOS, user responsible for data accuracy, Illinois governing law
- **`/faq`** — iOS/Android home screen install, forgot password flow, Illinois hour requirements (with buyer-beware caveat), add/switch students

## Test plan
- [ ] `/about`, `/privacy`, `/terms`, `/faq` load without being logged in
- [ ] Footer links appear on authenticated pages (dashboard, trips, etc.)
- [ ] GitHub links open correctly
- [ ] Illinois SOS link opens correctly
- [ ] iOS home screen instructions accurate on device

Closes #46, #47, #51, #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)