### PR TITLE
feat: show build version on login and register pages

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -132,6 +132,13 @@ export default function LoginPage() {
               <Link href="/terms" className="hover:text-white/60">Terms</Link>
               <Link href="/faq" className="hover:text-white/60">FAQ</Link>
             </div>
+            {(process.env.NEXT_PUBLIC_APP_VERSION || process.env.NEXT_PUBLIC_GIT_SHA) && (
+              <p className="text-center text-[10px] text-white/20 font-mono">
+                {process.env.NEXT_PUBLIC_APP_VERSION && `v${process.env.NEXT_PUBLIC_APP_VERSION}`}
+                {process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_GIT_SHA && ' · '}
+                {process.env.NEXT_PUBLIC_GIT_SHA && process.env.NEXT_PUBLIC_GIT_SHA.slice(0, 7)}
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -105,12 +105,21 @@ export default function RegisterPage() {
           </form>
 
           {/* Footer */}
-          <p className="text-center text-[10px] text-white/50 uppercase tracking-widest border-t border-white/20 pt-4">
-            Already have an account?{' '}
-            <Link href="/login" className="text-accent font-bold hover:opacity-80">
-              Sign In
-            </Link>
-          </p>
+          <div className="space-y-3 border-t border-white/20 pt-4">
+            <p className="text-center text-[10px] text-white/50 uppercase tracking-widest">
+              Already have an account?{' '}
+              <Link href="/login" className="text-accent font-bold hover:opacity-80">
+                Sign In
+              </Link>
+            </p>
+            {(process.env.NEXT_PUBLIC_APP_VERSION || process.env.NEXT_PUBLIC_GIT_SHA) && (
+              <p className="text-center text-[10px] text-white/20 font-mono">
+                {process.env.NEXT_PUBLIC_APP_VERSION && `v${process.env.NEXT_PUBLIC_APP_VERSION}`}
+                {process.env.NEXT_PUBLIC_APP_VERSION && process.env.NEXT_PUBLIC_GIT_SHA && ' · '}
+                {process.env.NEXT_PUBLIC_GIT_SHA && process.env.NEXT_PUBLIC_GIT_SHA.slice(0, 7)}
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Adds the same `v{version} · {sha}` version string to the footer of the login and register pages. Hidden when env vars are absent (local dev). Consistent with the authenticated app layout.

## Test plan
- [ ] Login and register pages show version in footer after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)